### PR TITLE
Hotfix for the uvicorn __version__ import issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 ]
 
 [dependency-groups]
+dev = [
+    "ipython>=9.3.0",
+]
 docs = [
     "furo>=2024.8.6",
     "linkify-it-py>=2.0.3",

--- a/src/dataio/__init__.py
+++ b/src/dataio/__init__.py
@@ -1,3 +1,6 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version(__name__)
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = version("dataio")

--- a/uv.lock
+++ b/uv.lock
@@ -275,6 +275,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "ipython" },
+]
 docs = [
     { name = "furo" },
     { name = "linkify-it-py" },
@@ -302,6 +305,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [{ name = "ipython", specifier = ">=9.3.0" }]
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "linkify-it-py", specifier = ">=2.0.3" },


### PR DESCRIPTION
the underlying issue is weird, requires further investigation.

Implementing a hotfix for now.

Resolves ENO-437