### PR TITLE
Akhil/eno 467 dataio add shapefile support

### DIFF
--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -532,7 +532,7 @@ def check_rate_limit_exceeded(user_email: str, access_point: str):
         raise
 
 
-def update_shapefile_download_count(user_email: str):
+def update_shapefile_rate_limit(user_email: str):
     session = Session()
     try:
         rate_limit = (

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -476,10 +476,33 @@ def get_parentID_of_region(region_id: str):
     session = Session()
     try:
         region = session.query(Region).filter(Region.region_id == region_id).first()
+        if region is None:
+            return None
         parent_id = region.parent_region_id
         return parent_id
     except Exception as e:
         logger.error(f"Error fetching parent id from DB: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def get_regions_by_ids(region_ids: List[str]):
+    """
+    Get region names by their region_ids.
+
+    Args:
+        region_ids: List of region_id strings
+
+    Returns:
+        Dict mapping region_id to region_name
+    """
+    session = Session()
+    try:
+        regions = session.query(Region).filter(Region.region_id.in_(region_ids)).all()
+        return {region.region_id: region.region_name for region in regions}
+    except Exception as e:
+        logger.error(f"Error fetching regions from DB: {str(e)}")
         raise
     finally:
         session.close()
@@ -503,7 +526,7 @@ def check_rate_limit_exceeded(user_email: str, access_point: str):
             rate_limit.number_of_attempts = 0
             session.commit()
             session.refresh(rate_limit)
-        return rate_limit.number_of_attempts >= rate_limit.max_limit_per_second
+        return rate_limit.number_of_attempts >= rate_limit.max_limit_per_minute
     except Exception as e:
         logger.error(f"Error checking rate limit exceeded: {str(e)}")
         raise

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -5,6 +5,7 @@ import bcrypt
 import secrets
 import dateutil
 from sqlalchemy import select
+from datetime import datetime, timedelta
 
 from dataio.api.database.config import Session
 from dataio.api.database.enums import ResourceType
@@ -23,6 +24,8 @@ from dataio.api.database.models import (
     DatasetTag,
     RawDataset,
     DatasetRawDataset,
+    Region,
+    RateLimit,
 )
 from dataio.api.auth.permissions import determine_highest_permission
 from dataio.api.models import (
@@ -464,6 +467,73 @@ def create_raw_dataset(raw_dataset: RawDatasetCreate):
         return raw_dataset
     except Exception as e:
         logger.error(f"Error creating raw dataset: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def get_parentID_of_region(region_id: str):
+    session = Session()
+    try:
+        region = session.query(Region).filter(Region.region_id == region_id).first()
+        parent_id = region.parent_region_id
+        return parent_id
+    except Exception as e:
+        logger.error(f"Error fetching parent id from DB: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def check_rate_limit_exceeded(user_email: str, access_point: str):
+    session = Session()
+    try:
+        rate_limit = (
+            session.query(RateLimit)
+            .filter(
+                RateLimit.user_email == user_email,
+                RateLimit.access_point == access_point,
+            )
+            .first()
+        )
+        if not rate_limit:
+            print("Rate limit not found")
+            return False
+        if rate_limit.last_access_timestamp < datetime.now() - timedelta(minutes=1):
+            rate_limit.number_of_attempts = 0
+            session.commit()
+            session.refresh(rate_limit)
+        return rate_limit.number_of_attempts >= rate_limit.max_limit_per_second
+    except Exception as e:
+        logger.error(f"Error checking rate limit exceeded: {str(e)}")
+        raise
+
+
+def update_shapefile_download_count(user_email: str):
+    session = Session()
+    try:
+        rate_limit = (
+            session.query(RateLimit)
+            .filter(
+                RateLimit.user_email == user_email
+                and RateLimit.access_point == "shapefile"
+            )
+            .first()
+        )
+        if not rate_limit:
+            rate_limit = RateLimit(
+                user_email=user_email, access_point="shapefile", number_of_attempts=1
+            )
+            session.add(rate_limit)
+            session.commit()
+            session.refresh(rate_limit)
+        else:
+            rate_limit.number_of_attempts += 1
+            rate_limit.last_access_timestamp = datetime.now()
+            session.commit()
+            session.refresh(rate_limit)
+    except Exception as e:
+        logger.error(f"Error updating shapefile download count: {str(e)}")
         raise
     finally:
         session.close()

--- a/src/dataio/api/database/models.py
+++ b/src/dataio/api/database/models.py
@@ -7,9 +7,11 @@ from sqlalchemy import (
     Text,
     Date,
     Boolean,
+    DateTime,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, declarative_base
+from datetime import datetime
 from dataio.api.database.enums import (
     AccessLevel,
     SpatialResolution,
@@ -145,3 +147,13 @@ class ResourceGroupMember(Base):
     resource_id = Column(Text, nullable=False, primary_key=True)
     resource_type = Column(SQLEnum(ResourceType), nullable=False)
     resource_json = Column(JSONB, nullable=True)
+
+
+class RateLimit(Base):
+    __tablename__ = "rate_limit"
+
+    user_email = Column(Text, primary_key=True)
+    number_of_attempts = Column(Integer, nullable=False, default=0)
+    max_limit_per_second = Column(Integer, nullable=False, default=5)
+    last_access_timestamp = Column(DateTime, nullable=False, default=datetime.now)
+    access_point = Column(Text, nullable=False)

--- a/src/dataio/api/database/models.py
+++ b/src/dataio/api/database/models.py
@@ -154,6 +154,6 @@ class RateLimit(Base):
 
     user_email = Column(Text, primary_key=True)
     number_of_attempts = Column(Integer, nullable=False, default=0)
-    max_limit_per_second = Column(Integer, nullable=False, default=5)
+    max_limit_per_minute = Column(Integer, nullable=False, default=5)
     last_access_timestamp = Column(DateTime, nullable=False, default=datetime.now)
     access_point = Column(Text, nullable=False)

--- a/src/dataio/api/routers/admin.py
+++ b/src/dataio/api/routers/admin.py
@@ -124,8 +124,6 @@ async def create_dataset(
     return admin_dataset_service.create_dataset(dataset)
 
 
-
-
 @admin_router.post(
     "/datasets/{dataset_id}/{bucket_type}/tables", tags=["admin/datasets"]
 )
@@ -202,3 +200,15 @@ async def get_collections(
     return admin_dataset_service.get_collections()
 
 
+#### SHAPEFILES
+
+
+@admin_router.post("/shapefiles/{region_id}", tags=["admin/shapefiles"])
+@admin_required
+async def post_shapefile(
+    shapefile: UploadFile,
+    region_id: str,
+    user: User = Depends(get_user),
+    admin_dataset_service: AdminDatasetService = Depends(AdminDatasetService),
+):
+    return admin_dataset_service.upload_shapefile(shapefile, region_id)

--- a/src/dataio/api/routers/user.py
+++ b/src/dataio/api/routers/user.py
@@ -33,11 +33,6 @@ async def get_datasets(
     return user_service.get_user_datasets(user, limit)
 
 
-##
-## FILESTORE MODIFICATION ENDPOINTS
-##
-
-
 @user_router.get("/datasets/{dataset_id}/{bucket_type}/tables")
 async def get_dataset_table_list(
     dataset_id: str,
@@ -49,3 +44,12 @@ async def get_dataset_table_list(
         f"DATASET_DOWNLOAD_REQUEST: {user.email} for dataset {dataset_id} bucket_type {bucket_type}"
     )
     return user_service.get_dataset_table_list(dataset_id, bucket_type, user)
+
+
+@user_router.get("/shapefiles/{region_id}")
+async def get_shapefile(
+    region_id: str,
+    user: User = Depends(get_user),
+    user_service: UserService = Depends(UserService),
+):
+    return user_service.get_shapefile(region_id, user.email)

--- a/src/dataio/api/routers/user.py
+++ b/src/dataio/api/routers/user.py
@@ -46,10 +46,25 @@ async def get_dataset_table_list(
     return user_service.get_dataset_table_list(dataset_id, bucket_type, user)
 
 
+@user_router.get("/shapefiles")
+async def get_shapefiles_list(
+    user: User = Depends(get_user), user_service: UserService = Depends(UserService)
+):
+    """
+    Get list of shapefiles available on S3.
+
+    Returns:
+    - List of available shapefiles with metadata
+    """
+    logger.info(f"SHAPEFILE_LIST_REQUEST: {user.email}")
+    return user_service.get_shapefiles_list(user)
+
+
 @user_router.get("/shapefiles/{region_id}")
 async def get_shapefile(
     region_id: str,
     user: User = Depends(get_user),
     user_service: UserService = Depends(UserService),
 ):
+    logger.info(f"SHAPEFILE_DOWNLOAD_REQUEST: {user.email} for region {region_id}")
     return user_service.get_shapefile(region_id, user.email)

--- a/src/dataio/api/services/admin_dataset_service.py
+++ b/src/dataio/api/services/admin_dataset_service.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException, UploadFile
+import gzip
 from dataio.api.models import (
     RawDatasetCreate,
     DataOwnerCreate,
@@ -154,3 +155,18 @@ class AdminDatasetService(BaseService):
                 status_code=500,
                 detail="Failed to delete dataset version file. Contact support.",
             )
+
+    def upload_shapefile(self, file: UploadFile, region_id: str):
+        """
+        Compress and upload shapefile to S3
+        """
+        try:
+            file_contents = file.file.read()
+            compressed_contents = gzip.compress(file_contents)
+            parent_id = database.get_parentID_of_region(region_id)
+            self.filestore_service.upload_shapefile(
+                compressed_contents, region_id, parent_id
+            )
+        except Exception as e:
+            self.logger.error("Failed to upload shapefile.")
+            raise HTTPException(status_code=500, detail="Failed to upload shape file.")

--- a/src/dataio/api/services/filestore_service.py
+++ b/src/dataio/api/services/filestore_service.py
@@ -1,5 +1,6 @@
 import boto3
 from botocore.client import Config
+from botocore.exceptions import ClientError
 import dotenv
 import os
 from fastapi import UploadFile
@@ -159,3 +160,34 @@ class FilestoreService(BaseService):
             .get()["Body"]
             .read()
         )
+
+    def list_shapefiles(self):
+        """
+        List all available shapefiles from S3 shapefiles/ prefix.
+        Returns organized data with parent_id and region_id information.
+        """
+        try:
+            shapefiles_list = []
+
+            for obj in self.bucket.objects.filter(Prefix="shapefiles/"):
+                if obj.key.endswith(".geojson.gz"):
+                    # Parse the key structure: shapefiles/{parent_id}/{region_id}.geojson.gz
+                    key_parts = obj.key.split("/")
+                    if len(key_parts) >= 3:
+                        parent_id = key_parts[1]
+                        region_filename = key_parts[2]
+                        region_id = region_filename.replace(".geojson.gz", "")
+
+                        shapefile_info = {
+                            "region_id": region_id,
+                            "parent_id": parent_id,
+                            "last_modified": obj.last_modified.isoformat()
+                            if obj.last_modified
+                            else None,
+                        }
+                        shapefiles_list.append(shapefile_info)
+
+            return shapefiles_list
+        except Exception as e:
+            self.logger.error(f"Failed to list shapefiles: {str(e)}")
+            raise e

--- a/src/dataio/api/services/filestore_service.py
+++ b/src/dataio/api/services/filestore_service.py
@@ -140,3 +140,22 @@ class FilestoreService(BaseService):
             ExpiresIn=3600,
         )
         return download_link
+
+    def upload_shapefile(self, file: bytes, region_id: str, parent_id: str):
+        """
+        Upload shapefile to S3
+        """
+        self.bucket.put_object(
+            Body=file,
+            Key=f"shapefiles/{parent_id}/{region_id}.geojson.gz",
+        )
+
+    def get_shapefile(self, region_id: str, parent_id: str):
+        """
+        Get shapefile from S3
+        """
+        return (
+            self.bucket.Object(f"shapefiles/{parent_id}/{region_id}.geojson.gz")
+            .get()["Body"]
+            .read()
+        )

--- a/src/dataio/api/services/user_service.py
+++ b/src/dataio/api/services/user_service.py
@@ -93,7 +93,7 @@ class UserService(BaseService):
                     status_code=429,
                     detail="You have reached the maximum number of requests. Please try again later.",
                 )
-            database.update_shapefile_download_count(user_email)
+            database.update_shapefile_rate_limit(user_email)
             compressed_shapefile_geojson = self.filestore_service.get_shapefile(
                 region_id, parent_id
             )

--- a/src/dataio/api/services/user_service.py
+++ b/src/dataio/api/services/user_service.py
@@ -1,6 +1,7 @@
 import json
 from fastapi import HTTPException
 import gzip
+from botocore.exceptions import ClientError
 from dataio.api.models import User, VersionType
 from dataio.api.database import functions as database
 from dataio.api.auth import (
@@ -81,7 +82,12 @@ class UserService(BaseService):
 
     def get_shapefile(self, region_id: str, user_email: str):
         try:
+            # check if region id is valid & whether we have it
             parent_id = database.get_parentID_of_region(region_id)
+
+            if parent_id is None:
+                raise HTTPException(status_code=400, detail="Invalid region id")
+
             if database.check_rate_limit_exceeded(user_email, "shapefile"):
                 raise HTTPException(
                     status_code=429,
@@ -94,8 +100,59 @@ class UserService(BaseService):
             shapefile_geojson = gzip.decompress(compressed_shapefile_geojson)
             shapefile_geojson = json.loads(shapefile_geojson)
             return shapefile_geojson
+        except HTTPException as e:
+            self.logger.error(f"Failed to get shapefile: {str(e)}")
+            raise e
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                self.logger.error("Shapefile not present in S3")
+                raise HTTPException(
+                    status_code=500,
+                    detail="Shapefile not present in our data-store. Please check shapefile list for available shapefiles.",
+                )
         except Exception as e:
             self.logger.error(f"Failed to get shapefile: {str(e)}")
             raise HTTPException(
                 status_code=500, detail="Failed to get shapefile. Contact support."
+            )
+
+    def get_shapefiles_list(self, user: User):
+        """
+        Get list of available shapefiles from S3 with region names.
+        """
+        try:
+            shapefiles_list = self.filestore_service.list_shapefiles()
+
+            # Get unique region_ids to fetch region names
+            region_ids = [shapefile["region_id"] for shapefile in shapefiles_list]
+            if not region_ids:
+                return []
+
+            # Get region names from database
+            region_names = database.get_regions_by_ids(region_ids)
+
+            # Add region names to the shapefile info
+            for shapefile in shapefiles_list:
+                shapefile["region_name"] = region_names.get(
+                    shapefile["region_id"], "Unknown"
+                )
+
+            # setting order of fields
+
+            shapefiles_list = [
+                {
+                    "region_id": shapefile["region_id"],
+                    "region_name": shapefile["region_name"],
+                    "parent_id": shapefile["parent_id"],
+                    "last_modified": shapefile["last_modified"],
+                }
+                for shapefile in shapefiles_list
+            ]
+
+            return shapefiles_list
+        except Exception as e:
+            self.logger.error(f"Failed to get shapefiles list: {str(e)}")
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to get shapefiles list. Contact support.",
             )

--- a/src/dataio/api/services/user_service.py
+++ b/src/dataio/api/services/user_service.py
@@ -1,4 +1,6 @@
+import json
 from fastapi import HTTPException
+import gzip
 from dataio.api.models import User, VersionType
 from dataio.api.database import functions as database
 from dataio.api.auth import (
@@ -75,4 +77,25 @@ class UserService(BaseService):
             self.logger.error(f"Failed to get dataset files: {str(e)}")
             raise HTTPException(
                 status_code=500, detail="Failed to get dataset files. Contact support."
+            )
+
+    def get_shapefile(self, region_id: str, user_email: str):
+        try:
+            parent_id = database.get_parentID_of_region(region_id)
+            if database.check_rate_limit_exceeded(user_email, "shapefile"):
+                raise HTTPException(
+                    status_code=429,
+                    detail="You have reached the maximum number of requests. Please try again later.",
+                )
+            database.update_shapefile_download_count(user_email)
+            compressed_shapefile_geojson = self.filestore_service.get_shapefile(
+                region_id, parent_id
+            )
+            shapefile_geojson = gzip.decompress(compressed_shapefile_geojson)
+            shapefile_geojson = json.loads(shapefile_geojson)
+            return shapefile_geojson
+        except Exception as e:
+            self.logger.error(f"Failed to get shapefile: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail="Failed to get shapefile. Contact support."
             )

--- a/src/dataio/db/migrations/002_helper_functions_to_add_datasets.sql
+++ b/src/dataio/db/migrations/002_helper_functions_to_add_datasets.sql
@@ -123,6 +123,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-SELECT add_migration(2, '002_helper_functions_to_add_datasets.sql');
+SELECT add_migration(2, '002_helper_functions_to_add_datasets');
 
 COMMIT;

--- a/src/dataio/db/migrations/003_users_and_permissions.sql
+++ b/src/dataio/db/migrations/003_users_and_permissions.sql
@@ -93,4 +93,7 @@ CREATE TRIGGER validate_group_membership_trigger
     FOR EACH ROW
     EXECUTE FUNCTION validate_group_membership();
 
+SELECT add_migration(3, '003_users_and_permissions');
+
+
 COMMIT;

--- a/src/dataio/db/migrations/004_rate_limit_table.sql
+++ b/src/dataio/db/migrations/004_rate_limit_table.sql
@@ -9,4 +9,6 @@ CREATE TABLE rate_limit (
     PRIMARY KEY (user_email, access_point)
 );
 
+SELECT add_migration(4, '004_rate_limit_table');
+
 COMMIT;

--- a/src/dataio/db/migrations/004_rate_limit_table.sql
+++ b/src/dataio/db/migrations/004_rate_limit_table.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE rate_limit (
+    user_email TEXT NOT NULL,
+    number_of_attempts INT NOT NULL DEFAULT 0,
+    max_limit_per_minute INT NOT NULL DEFAULT 5,
+    last_access_timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
+    access_point TEXT NOT NULL,
+    PRIMARY KEY (user_email, access_point)
+);
+
+COMMIT;


### PR DESCRIPTION
Added shapefile functionality & Rate limit for shapefile download. Rate limits table made in such a way that it is extendable for other endpoints as well, for eg: download_dataset.