### PR TITLE
feat: serve sphinx docs at the root of fastapi

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -36,6 +36,7 @@ jobs:
           cp /home/ubuntu/infra/.dataio-env /home/ubuntu/staging/dataio/.env
           cd dataio
           mkdir logs
-          uv sync
+          uv sync --group docs
+          uv run sphinx-build -b html docs/source docs/build
           sudo supervisorctl restart dataio-app
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -138,3 +138,7 @@ When you list the tables in a dataset, you will get a list of dictionaries, each
 :::{warning}
 The download link is a signed link that will expire in 1 hour.
 :::
+
+## Endpoints
+
+The API endpoints are documented in the [Endpoints](https://staging.dataio.artpark.ai/endpoints) page.

--- a/src/dataio/api/main.py
+++ b/src/dataio/api/main.py
@@ -1,18 +1,23 @@
-from fastapi import FastAPI
 import logging
-from dataio.api.routers.user import user_router
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
 from dataio.api.routers.admin import admin_router
+from dataio.api.routers.user import user_router
 
 # Set up logging
 log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-logging.basicConfig(level=logging.INFO, format=log_format, filename="api.log", filemode="a")
+logging.basicConfig(
+    level=logging.INFO, format=log_format, filename="api.log", filemode="a"
+)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Dataset Management System API")
+app = FastAPI(
+    title="Dataset Management System API", docs_url="/endpoints", redoc_url=None
+)
 
 app.include_router(user_router)
 app.include_router(admin_router)
 
-@app.get("/")
-async def root():
-    return {"message": "Welcome to Dataset Management System API"}
+app.mount("/", StaticFiles(directory="docs/build/", html=True), name="docs")


### PR DESCRIPTION
Fastapi app root now includes docs.

Endpoints are served at {base_url}/endpoint