### PR TITLE
feat: Excel-matching global/category ID suggestion logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,8 @@ dmypy.json
 *.yaml
 !.env.example
 data/*
+staging-data/*
+ARTPARK Data Catalogue
 data_backup_20260716_120337/*
 **/data_inserts/**
 *.zip

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 import logging
+import re
 from sqlalchemy.orm import joinedload
 import bcrypt
 import secrets
@@ -509,28 +510,41 @@ def delete_dataset(dataset_id: str):
         session.close()
 
 
+def get_next_dataset_serial_number(session=None) -> int:
+    """The next number in the catalogue-wide dataset ID counter (see
+    suggest_next_dataset_id) - independent of collection, since this counter
+    is global. Accepts an optional existing session so callers already
+    holding one (e.g. suggest_next_dataset_id) don't open a second.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        existing_ids = session.query(Dataset.ds_id).all()
+        reserved_ids = session.query(ReservedDatasetID.ds_id).all()
+        max_suffix = 0
+        suffix_pattern = re.compile(r"DS(\d{4})$")
+        for (ds_id,) in [*existing_ids, *reserved_ids]:
+            match = suffix_pattern.search(ds_id or "")
+            if match:
+                max_suffix = max(max_suffix, int(match.group(1)))
+        return max_suffix + 1
+    finally:
+        if owns_session:
+            session.close()
+
+
 def suggest_next_dataset_id(collection_id: str) -> str:
+    """Suggest the next dataset ID, matching the master catalogue's numbering:
+    the numeric suffix is a single counter shared across every dataset in the
+    catalogue (not scoped to one collection), so it always keeps pace with
+    whatever the catalogue would assign next, regardless of which collection
+    the new dataset belongs to.
+    """
     session = Session()
     try:
-        existing_ids = (
-            session.query(Dataset.ds_id)
-            .filter(Dataset.ds_id.like(f"{collection_id}DS%"))
-            .all()
-        )
-        reserved_ids = (
-            session.query(ReservedDatasetID.ds_id)
-            .filter(ReservedDatasetID.ds_id.like(f"{collection_id}DS%"))
-            .all()
-        )
-        max_suffix = 0
+        next_number = get_next_dataset_serial_number(session)
         prefix = f"{collection_id}DS"
-        for (ds_id,) in [*existing_ids, *reserved_ids]:
-            if not ds_id.startswith(prefix):
-                continue
-            suffix = ds_id[len(prefix):]
-            if len(suffix) == 4 and suffix.isdigit():
-                max_suffix = max(max_suffix, int(suffix))
-        return f"{prefix}{max_suffix + 1:04d}"
+        return f"{prefix}{next_number:04d}"
     except Exception as e:
         logger.error(f"Error suggesting dataset id: {str(e)}")
         raise
@@ -538,29 +552,42 @@ def suggest_next_dataset_id(collection_id: str) -> str:
         session.close()
 
 
+def suggest_next_raw_dataset_id_for_category(category_id: str, session=None) -> str:
+    """The next raw dataset ID for a category (e.g. "CS"), matching the
+    master catalogue's numbering: the counter is shared across every
+    collection in that category (all of CS0001, CS0007, CS0026... share one
+    "CS" counter), using the catalogue's own unpadded "{category}RDS{n}"
+    format (e.g. CSRDS16).
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        existing_ids = session.query(RawDataset.rds_id).all()
+        max_suffix = 0
+        suffix_pattern = re.compile(rf"^{re.escape(category_id)}RDS(\d+)$")
+        for (rds_id,) in existing_ids:
+            match = suffix_pattern.match(rds_id or "")
+            if match:
+                max_suffix = max(max_suffix, int(match.group(1)))
+        return f"{category_id}RDS{max_suffix + 1}"
+    finally:
+        if owns_session:
+            session.close()
+
+
 def suggest_next_raw_dataset_id(collection_id: str) -> str:
+    """Suggest the next raw dataset ID for the category that collection_id
+    belongs to - see suggest_next_raw_dataset_id_for_category.
+    """
     session = Session()
     try:
-        existing_ids = (
-            session.query(RawDataset.rds_id)
-            .filter(RawDataset.rds_id.like(f"{collection_id}%"))
-            .all()
+        collection = (
+            session.query(Collection)
+            .filter(Collection.collection_id == collection_id)
+            .first()
         )
-        max_suffix = 0
-        prefix = f"{collection_id}RDS"
-        import re
-
-        for (rds_id,) in existing_ids:
-            if rds_id.startswith(prefix):
-                suffix = rds_id[len(prefix) :]
-                if len(suffix) == 4 and suffix.isdigit():
-                    max_suffix = max(max_suffix, int(suffix))
-            elif "-raw-" in rds_id:
-                m = re.search(r"-raw-(\d+)$", rds_id)
-                if m:
-                    max_suffix = max(max_suffix, int(m.group(1)))
-
-        return f"{prefix}{max_suffix + 1:04d}"
+        category_id = collection.category_id if collection else re.sub(r"\d+$", "", collection_id)
+        return suggest_next_raw_dataset_id_for_category(category_id, session)
     except Exception as e:
         logger.error(f"Error suggesting raw dataset id: {str(e)}")
         raise

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -558,15 +558,21 @@ def suggest_next_raw_dataset_id_for_category(category_id: str, session=None) -> 
     collection in that category (all of CS0001, CS0007, CS0026... share one
     "CS" counter), using the catalogue's own unpadded "{category}RDS{n}"
     format (e.g. CSRDS16).
+
+    Also folds in rds_ids still stored in the older per-collection format
+    (e.g. CS0002RDS0003) so a category that already has raw datasets under
+    the old scheme doesn't restart its counter from 1 and collide with them.
     """
     owns_session = session is None
     session = session or Session()
     try:
         existing_ids = session.query(RawDataset.rds_id).all()
         max_suffix = 0
-        suffix_pattern = re.compile(rf"^{re.escape(category_id)}RDS(\d+)$")
+        new_format_pattern = re.compile(rf"^{re.escape(category_id)}RDS(\d+)$")
+        legacy_format_pattern = re.compile(rf"^{re.escape(category_id)}\d{{4}}RDS(\d{{4}})$")
         for (rds_id,) in existing_ids:
-            match = suffix_pattern.match(rds_id or "")
+            rds_id = rds_id or ""
+            match = new_format_pattern.match(rds_id) or legacy_format_pattern.match(rds_id)
             if match:
                 max_suffix = max(max_suffix, int(match.group(1)))
         return f"{category_id}RDS{max_suffix + 1}"

--- a/src/dataio/api/routers/web.py
+++ b/src/dataio/api/routers/web.py
@@ -1345,6 +1345,15 @@ async def admin_suggest_dataset_id(
     return admin_service.suggest_next_dataset_id(user, collection_id)
 
 
+@web_router.get("/admin/datasets/next-id-number", tags=["web-admin/datasets"])
+async def admin_get_next_dataset_id_number(
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    """The next dataset ID number, catalogue-wide (independent of collection)."""
+    return admin_service.get_next_dataset_id_number(user)
+
+
 @web_router.get("/admin/raw-datasets/suggest-id", tags=["web-admin/datasets"])
 async def admin_suggest_raw_dataset_id(
     collection_id: str,
@@ -1353,6 +1362,16 @@ async def admin_suggest_raw_dataset_id(
 ):
     """Suggest the next sequential raw dataset ID for a collection."""
     return admin_service.suggest_next_raw_dataset_id(user, collection_id)
+
+
+@web_router.get("/admin/raw-datasets/suggest-id-by-category", tags=["web-admin/datasets"])
+async def admin_suggest_raw_dataset_id_by_category(
+    category_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    """Suggest the next raw dataset ID for a category (shared across its collections)."""
+    return admin_service.suggest_next_raw_dataset_id_for_category(user, category_id)
 
 
 @web_router.get("/admin/dataset-id-reservations", tags=["web-admin/datasets"])

--- a/src/dataio/api/services/admin_dataset_service.py
+++ b/src/dataio/api/services/admin_dataset_service.py
@@ -193,6 +193,32 @@ class AdminDatasetService(BaseService):
                 status_code=500, detail="Failed to update dataset. Contact support."
             ) from e
 
+    def get_next_dataset_id_number(self):
+        try:
+            return {"next_number": database.get_next_dataset_serial_number()}
+        except Exception as e:
+            self.logger.error(f"Failed to get next dataset id number: {e!s}")
+            raise HTTPException(
+                status_code=500, detail="Failed to get next dataset ID number. Contact support."
+            ) from e
+
+    def suggest_next_raw_dataset_id_for_category(self, category_id: str):
+        try:
+            if not category_id.strip():
+                raise ValidationError("Category ID is required")
+            return {
+                "category_id": category_id,
+                "suggested_raw_dataset_id": database.suggest_next_raw_dataset_id_for_category(category_id),
+            }
+        except ValidationError as e:
+            self.logger.error(f"Failed to suggest raw dataset id for category: {e!s}")
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        except Exception as e:
+            self.logger.error(f"Failed to suggest raw dataset id for category: {e!s}")
+            raise HTTPException(
+                status_code=500, detail="Failed to suggest raw dataset ID. Contact support."
+            ) from e
+
     def suggest_next_dataset_id(self, collection_id: str):
         try:
             if not collection_id.strip():

--- a/src/dataio/api/services/web_admin_service.py
+++ b/src/dataio/api/services/web_admin_service.py
@@ -1262,9 +1262,17 @@ class WebAdminService(BaseService):
         self._require_admin(admin_user)
         return self.admin_dataset_service.suggest_next_dataset_id(collection_id)
 
+    def get_next_dataset_id_number(self, admin_user: User) -> dict:
+        self._require_admin(admin_user)
+        return self.admin_dataset_service.get_next_dataset_id_number()
+
     def suggest_next_raw_dataset_id(self, admin_user: User, collection_id: str) -> dict:
         self._require_admin(admin_user)
         return self.admin_dataset_service.suggest_next_raw_dataset_id(collection_id)
+
+    def suggest_next_raw_dataset_id_for_category(self, admin_user: User, category_id: str) -> dict:
+        self._require_admin(admin_user)
+        return self.admin_dataset_service.suggest_next_raw_dataset_id_for_category(category_id)
 
     def list_reserved_dataset_ids(
         self,

--- a/web/src/components/admin/DatasetAdminManager.tsx
+++ b/web/src/components/admin/DatasetAdminManager.tsx
@@ -138,10 +138,13 @@ export default function DatasetAdminManager({
   const [rawDatasetCollectionId, setRawDatasetCollectionId] = useState('');
   const [selectedRawDatasetId, setSelectedRawDatasetId] = useState('');
   const [rawDatasetEditForm, setRawDatasetEditForm] = useState({ title: '', source: '' });
-  const [idsLookupCollectionId, setIdsLookupCollectionId] = useState('');
-  const [idsLookupResult, setIdsLookupResult] = useState<{ collectionId: string; nextDatasetId: string; nextRawDatasetId: string } | null>(null);
-  const [idsLookupLoading, setIdsLookupLoading] = useState(false);
-  const idsLookupRequestRef = useRef('');
+  const [nextDatasetIdNumber, setNextDatasetIdNumber] = useState<number | null>(null);
+  const [nextDatasetIdLoading, setNextDatasetIdLoading] = useState(false);
+  const [idsLookupCategoryId, setIdsLookupCategoryId] = useState('');
+  const [nextRawDatasetIdByCategory, setNextRawDatasetIdByCategory] = useState<{ categoryId: string; rdsId: string } | null>(null);
+  const [nextRawDatasetIdLoading, setNextRawDatasetIdLoading] = useState(false);
+  const nextDatasetIdRequestRef = useRef(0);
+  const nextRawDatasetIdRequestRef = useRef('');
   const rawDatasetIdSuggestRequestRef = useRef('');
   const [loading, setLoading] = useState(true);
   const [loadingDatasetDetail, setLoadingDatasetDetail] = useState(false);
@@ -414,6 +417,18 @@ export default function DatasetAdminManager({
     };
   };
 
+  const categoryOptions = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const collection of collections) {
+      if (!byId.has(collection.category_id)) {
+        byId.set(collection.category_id, collection.category_name);
+      }
+    }
+    return Array.from(byId.entries())
+      .map(([category_id, category_name]) => ({ category_id, category_name }))
+      .sort((a, b) => a.category_id.localeCompare(b.category_id));
+  }, [collections]);
+
   const parsedReadmeHtml = useMemo(() => {
     if (!readmeDraft.trim()) return '';
     return marked.parse(readmeDraft) as string;
@@ -433,33 +448,6 @@ export default function DatasetAdminManager({
     }
   }, [dataDictionaryDraft]);
 
-  const dsIdSequenceNote = useMemo(() => {
-    const actual = importPreview?.dataset.ds_id;
-    const suggested = importPreview?.suggested_dataset_id;
-    if (!actual || !suggested) return null;
-
-    const idPattern = /^([A-Z]{2}\d{4}DS)(\d{4})$/;
-    const actualMatch = actual.match(idPattern);
-    const suggestedMatch = suggested.match(idPattern);
-    if (!actualMatch || !suggestedMatch || actualMatch[1] !== suggestedMatch[1]) return null;
-
-    const actualNum = parseInt(actualMatch[2], 10);
-    const suggestedNum = parseInt(suggestedMatch[2], 10);
-    if (actualNum === suggestedNum) return null;
-
-    const prefix = actualMatch[1];
-    const pad = (n: number) => String(n).padStart(4, '0');
-
-    if (actualNum > suggestedNum) {
-      const gapRange =
-        suggestedNum === actualNum - 1
-          ? `${prefix}${pad(suggestedNum)}`
-          : `${prefix}${pad(suggestedNum)}–${prefix}${pad(actualNum - 1)}`;
-      return `This is higher than the next sequential ID (${suggested}) - ${gapRange} will remain unused in this collection.`;
-    }
-
-    return `This is lower than the next sequential ID (${suggested}) - it fills a previously unused ID in the sequence.`;
-  }, [importPreview]);
 
   const applyImportPreview = (preview: AdminDatasetPackagePreview) => {
     setImportPreview(preview);
@@ -513,32 +501,42 @@ export default function DatasetAdminManager({
     }
   };
 
-  const handleLookupNextIds = async (collectionId: string) => {
-    setIdsLookupCollectionId(collectionId);
-    setIdsLookupResult(null);
-    idsLookupRequestRef.current = collectionId;
-    if (!collectionId) return;
-    setIdsLookupLoading(true);
+  const handleGetNextDatasetId = async () => {
+    const requestId = nextDatasetIdRequestRef.current + 1;
+    nextDatasetIdRequestRef.current = requestId;
+    setNextDatasetIdLoading(true);
     setErrorMessage('');
     try {
-      const [dsResponse, rdsResponse] = await Promise.all([
-        api.adminSuggestDatasetId(collectionId),
-        api.adminSuggestRawDatasetId(collectionId),
-      ]);
-      // Ignore this response if a newer lookup has since been kicked off -
-      // otherwise a slower, stale request can overwrite a faster, newer one.
-      if (idsLookupRequestRef.current !== collectionId) return;
-      setIdsLookupResult({
-        collectionId,
-        nextDatasetId: dsResponse.suggested_dataset_id,
-        nextRawDatasetId: rdsResponse.suggested_raw_dataset_id,
-      });
+      const response = await api.adminGetNextDatasetIdNumber();
+      if (nextDatasetIdRequestRef.current !== requestId) return;
+      setNextDatasetIdNumber(response.next_number);
     } catch (err) {
-      if (idsLookupRequestRef.current !== collectionId) return;
-      setErrorMessage(err instanceof Error ? err.message : 'Failed to look up next available IDs');
+      if (nextDatasetIdRequestRef.current !== requestId) return;
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to get next dataset ID number');
     } finally {
-      if (idsLookupRequestRef.current === collectionId) {
-        setIdsLookupLoading(false);
+      if (nextDatasetIdRequestRef.current === requestId) {
+        setNextDatasetIdLoading(false);
+      }
+    }
+  };
+
+  const handleGetNextRawDatasetIdForCategory = async (categoryId: string) => {
+    setIdsLookupCategoryId(categoryId);
+    setNextRawDatasetIdByCategory(null);
+    nextRawDatasetIdRequestRef.current = categoryId;
+    if (!categoryId) return;
+    setNextRawDatasetIdLoading(true);
+    setErrorMessage('');
+    try {
+      const response = await api.adminSuggestRawDatasetIdByCategory(categoryId);
+      if (nextRawDatasetIdRequestRef.current !== categoryId) return;
+      setNextRawDatasetIdByCategory({ categoryId, rdsId: response.suggested_raw_dataset_id });
+    } catch (err) {
+      if (nextRawDatasetIdRequestRef.current !== categoryId) return;
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to get next raw dataset ID');
+    } finally {
+      if (nextRawDatasetIdRequestRef.current === categoryId) {
+        setNextRawDatasetIdLoading(false);
       }
     }
   };
@@ -1500,47 +1498,63 @@ export default function DatasetAdminManager({
         <div>
           <h3 class="text-lg font-semibold text-slate-900">Next Available IDs</h3>
           <p class="mt-1 text-sm text-slate-600">
-            Pick a collection to see the next free dataset ID and raw dataset ID - nothing is created or reserved, this is a read-only lookup for authoring metadata.yaml / info.yml.
+            Read-only lookups for authoring metadata.yaml / info.yml - nothing is created or reserved.
           </p>
         </div>
 
-        <div class="mt-4 grid gap-4 md:grid-cols-[1fr_auto]">
-          <select
-            value={idsLookupCollectionId}
-            onChange={(e) => handleLookupNextIds((e.currentTarget as HTMLSelectElement).value)}
-            class="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm shadow-sm"
-          >
-            <option value="">Select collection</option>
-            {collections.map((collection) => (
-              <option key={collection.id} value={collection.collection_id}>
-                {collection.collection_id} - {collection.collection_name}
-              </option>
-            ))}
-          </select>
-          <button
-            type="button"
-            onClick={() => handleLookupNextIds(idsLookupCollectionId)}
-            disabled={!idsLookupCollectionId || idsLookupLoading}
-            class="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 disabled:opacity-50"
-          >
-            {idsLookupLoading ? 'Looking up…' : 'Refresh'}
-          </button>
-        </div>
-
-        {idsLookupResult ? (
-          <div class="mt-4 grid gap-4 sm:grid-cols-2">
-            <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-              <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Next Dataset ID</div>
-              <div class="mt-1 font-mono text-lg font-semibold text-slate-900">{idsLookupResult.nextDatasetId}</div>
-            </div>
-            <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-              <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Next Raw Dataset ID</div>
-              <div class="mt-1 font-mono text-lg font-semibold text-slate-900">{idsLookupResult.nextRawDatasetId}</div>
-            </div>
+        <div class="mt-4 grid gap-4 sm:grid-cols-2">
+          <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Next Dataset ID Number</div>
+            <p class="mt-1 text-xs text-slate-500">
+              Shared across every collection - attach your collection's own code as the prefix, e.g. CS0026DS{String(nextDatasetIdNumber ?? 0).padStart(4, '0')}.
+            </p>
+            <button
+              type="button"
+              onClick={handleGetNextDatasetId}
+              disabled={nextDatasetIdLoading}
+              class="mt-3 rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 disabled:opacity-50"
+            >
+              {nextDatasetIdLoading ? 'Looking up…' : 'Get Available ID'}
+            </button>
+            {nextDatasetIdNumber !== null ? (
+              <div class="mt-3 font-mono text-lg font-semibold text-slate-900">
+                {String(nextDatasetIdNumber).padStart(4, '0')}
+              </div>
+            ) : null}
           </div>
-        ) : (
-          <p class="mt-4 text-sm text-slate-500">Select a collection above to see its next available IDs.</p>
-        )}
+
+          <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Next Raw Dataset ID</div>
+            <p class="mt-1 text-xs text-slate-500">Shared across every collection in the same category.</p>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <select
+                value={idsLookupCategoryId}
+                onChange={(e) => handleGetNextRawDatasetIdForCategory((e.currentTarget as HTMLSelectElement).value)}
+                class="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm shadow-sm"
+              >
+                <option value="">Select category</option>
+                {categoryOptions.map((category) => (
+                  <option key={category.category_id} value={category.category_id}>
+                    {category.category_id} - {category.category_name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => handleGetNextRawDatasetIdForCategory(idsLookupCategoryId)}
+                disabled={!idsLookupCategoryId || nextRawDatasetIdLoading}
+                class="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 disabled:opacity-50"
+              >
+                {nextRawDatasetIdLoading ? 'Looking up…' : 'Get Available ID'}
+              </button>
+            </div>
+            {nextRawDatasetIdByCategory ? (
+              <div class="mt-3 font-mono text-lg font-semibold text-slate-900">
+                {nextRawDatasetIdByCategory.rdsId}
+              </div>
+            ) : null}
+          </div>
+          </div>
       </section>
       ) : null}
 
@@ -1626,11 +1640,6 @@ export default function DatasetAdminManager({
                 <span>{importCsvFiles.length} CSV file(s) selected</span>
                 <span>{importPreview.can_import ? 'Ready to import' : 'Needs review'}</span>
               </div>
-              {dsIdSequenceNote ? (
-                <div class="mt-2 rounded-lg bg-amber-100 px-3 py-2 text-xs font-medium text-amber-800">
-                  {importPreview.dataset.ds_id}: {dsIdSequenceNote}
-                </div>
-              ) : null}
             </div>
 
             {importPreview.findings.length > 0 ? (

--- a/web/src/components/admin/DatasetAdminManager.tsx
+++ b/web/src/components/admin/DatasetAdminManager.tsx
@@ -144,7 +144,7 @@ export default function DatasetAdminManager({
   const [nextRawDatasetIdByCategory, setNextRawDatasetIdByCategory] = useState<{ categoryId: string; rdsId: string } | null>(null);
   const [nextRawDatasetIdLoading, setNextRawDatasetIdLoading] = useState(false);
   const nextDatasetIdRequestRef = useRef(0);
-  const nextRawDatasetIdRequestRef = useRef('');
+  const nextRawDatasetIdRequestRef = useRef(0);
   const rawDatasetIdSuggestRequestRef = useRef('');
   const [loading, setLoading] = useState(true);
   const [loadingDatasetDetail, setLoadingDatasetDetail] = useState(false);
@@ -523,19 +523,20 @@ export default function DatasetAdminManager({
   const handleGetNextRawDatasetIdForCategory = async (categoryId: string) => {
     setIdsLookupCategoryId(categoryId);
     setNextRawDatasetIdByCategory(null);
-    nextRawDatasetIdRequestRef.current = categoryId;
+    const requestId = nextRawDatasetIdRequestRef.current + 1;
+    nextRawDatasetIdRequestRef.current = requestId;
     if (!categoryId) return;
     setNextRawDatasetIdLoading(true);
     setErrorMessage('');
     try {
       const response = await api.adminSuggestRawDatasetIdByCategory(categoryId);
-      if (nextRawDatasetIdRequestRef.current !== categoryId) return;
+      if (nextRawDatasetIdRequestRef.current !== requestId) return;
       setNextRawDatasetIdByCategory({ categoryId, rdsId: response.suggested_raw_dataset_id });
     } catch (err) {
-      if (nextRawDatasetIdRequestRef.current !== categoryId) return;
+      if (nextRawDatasetIdRequestRef.current !== requestId) return;
       setErrorMessage(err instanceof Error ? err.message : 'Failed to get next raw dataset ID');
     } finally {
-      if (nextRawDatasetIdRequestRef.current === categoryId) {
+      if (nextRawDatasetIdRequestRef.current === requestId) {
         setNextRawDatasetIdLoading(false);
       }
     }
@@ -1506,7 +1507,9 @@ export default function DatasetAdminManager({
           <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
             <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Next Dataset ID Number</div>
             <p class="mt-1 text-xs text-slate-500">
-              Shared across every collection - attach your collection's own code as the prefix, e.g. CS0026DS{String(nextDatasetIdNumber ?? 0).padStart(4, '0')}.
+              {nextDatasetIdNumber !== null
+                ? `Shared across every collection - attach your collection's own code as the prefix, e.g. CS0026DS${String(nextDatasetIdNumber).padStart(4, '0')}.`
+                : "Shared across every collection - attach your collection's own code as the prefix (e.g. CS0026DS####)."}
             </p>
             <button
               type="button"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,7 +14,9 @@ import type {
   DatasetManifestRecord,
   DataOwnersResponse,
   DatasetIdSuggestion,
+  NextDatasetIdNumber,
   RawDatasetIdSuggestion,
+  RawDatasetIdSuggestionByCategory,
   DatasetsResponse,
   DocumentationSyncCheckResponse,
   DocumentationSyncRunResponse,
@@ -780,6 +782,10 @@ class ApiClient {
     );
   }
 
+  async adminGetNextDatasetIdNumber() {
+    return this.request<NextDatasetIdNumber>('/admin/datasets/next-id-number');
+  }
+
   async adminListReservedDatasetIds(params?: { search?: string; limit?: number; offset?: number }) {
     const searchParams = new URLSearchParams();
     if (params?.search) searchParams.set('search', params.search);
@@ -952,6 +958,12 @@ class ApiClient {
   async adminSuggestRawDatasetId(collectionId: string) {
     return this.request<RawDatasetIdSuggestion>(
       `/admin/raw-datasets/suggest-id?collection_id=${encodeURIComponent(collectionId)}`
+    );
+  }
+
+  async adminSuggestRawDatasetIdByCategory(categoryId: string) {
+    return this.request<RawDatasetIdSuggestionByCategory>(
+      `/admin/raw-datasets/suggest-id-by-category?category_id=${encodeURIComponent(categoryId)}`
     );
   }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -265,6 +265,15 @@ export interface RawDatasetIdSuggestion {
   suggested_raw_dataset_id: string;
 }
 
+export interface NextDatasetIdNumber {
+  next_number: number;
+}
+
+export interface RawDatasetIdSuggestionByCategory {
+  category_id: string;
+  suggested_raw_dataset_id: string;
+}
+
 export interface DocumentationSyncDatasetStatus {
   ds_id: string;
   needs_update: boolean;


### PR DESCRIPTION
## Summary
- `ds_id` suggestion now uses a single global counter across all datasets/reserved IDs (matches the production Excel catalogue's `DS ID (Stable)` logic), instead of a per-collection counter.
- `rds_id` suggestion now uses a per-category counter in the unpadded format already used in S3 (e.g. `CSRDS16`), added as a new `suggest_next_raw_dataset_id_for_category` alongside the existing collection-based helper.
- Simplified the admin "Next ID" tab: dataset ID is now a single button (no collection picker needed since it's global); raw dataset ID keeps a category picker (dropped collection, since the counter is category-scoped).
- Removed the import-preview "gap in numbering" warning, since it no longer reflects real behavior under the new global-counter logic.

## Test plan
- [x] Verified new suggestion functions against a local Postgres DB with sample datasets/reserved IDs
- [x] `npm run build` passes for the frontend changes
- [ ] Manual end-to-end check on staging: use "Get Available ID" in the admin panel, then import a dataset using the suggested ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate admin tools to find the next dataset number across the catalogue and suggest raw dataset IDs by category.
  * Updated the “Next Available IDs” screen with independent dataset and raw dataset lookup cards.
  * Added category selection for raw dataset ID suggestions.
* **Bug Fixes**
  * Improved ID generation to prevent duplicate or conflicting dataset and raw dataset identifiers.
  * Removed outdated import preview messaging about ID sequence gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->