### PR TITLE
Deterministic + LLM metadata drafting: leaner prompts, one-click dataset upload, form UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,9 +141,29 @@ OPENROUTER_API_KEY=
 # Base URL (optional, default shown)
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
-# Model to use (see https://openrouter.ai/models for available models)
-# Examples: anthropic/claude-3.5-sonnet, openai/gpt-4-turbo, google/gemini-pro
-OPENROUTER_MODEL_ID=anthropic/claude-3.5-sonnet
+# Model to use (see https://openrouter.ai/models for available models -
+# check this list before deploying, OpenRouter retires/renames slugs over time)
+# Examples: anthropic/claude-sonnet-5, openai/gpt-4-turbo, google/gemini-pro
+OPENROUTER_MODEL_ID=anthropic/claude-sonnet-5
+
+# =============================================================================
+# Metadata Drafter (LLM-drafted metadata.yaml, pending curator review)
+# =============================================================================
+# Uses the same OPENROUTER_API_KEY/OPENROUTER_BASE_URL above regardless of
+# CHAT_PROVIDER - drafting always goes through OpenRouter, not Bedrock.
+# Model override (optional - falls back to OPENROUTER_MODEL_ID if unset).
+DRAFTER_MODEL_ID=anthropic/claude-sonnet-5
+
+# Extended-thinking/reasoning controls (both optional, unset by default - the
+# drafter is already slow on large CSVs, so reasoning tokens are opt-in, not a
+# silent extra cost/latency hit). Set at most one of these:
+# DRAFTER_REASONING_EFFORT=high          # low | medium | high
+# DRAFTER_REASONING_MAX_TOKENS=8000      # explicit thinking-token budget; takes priority over EFFORT if both are set
+
+# Where uploaded CSVs/digitization logs from the "Generate draft" web form
+# are stored on local disk while a draft is pending review (drafts are not
+# in S3 yet - that only happens on approval).
+DRAFT_UPLOAD_DIR=data/manifest_draft_uploads
 
 # =============================================================================
 # SDK Configuration (for CLI/SDK usage)

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ dmypy.json
 *.csv
 *.yaml
 !.env.example
+# Reference data the API reads at runtime (region history, canonical enum
+# registries) - not generated dataset output, must stay tracked.
+!src/dataio/api/reference_data/*.yaml
 data/*
 staging-data/*
 ARTPARK Data Catalogue

--- a/.gitignore
+++ b/.gitignore
@@ -153,8 +153,10 @@ data_backup_20260716_120337/*
 **/data_inserts/**
 *.zip
 .data/
+meta-data-Generation/*
 data/
 *.nc
+
 *.geojson
 # AI Files
 
@@ -166,3 +168,5 @@ reformat_yaml.py
 dataio_naming_policy.md
 Datasets_Uploaded_Dataio.md
 
+metadata_field_reference.md
+ARTPARK Data Catalogue.xlsx

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ Datasets_Uploaded_Dataio.md
 
 metadata_field_reference.md
 ARTPARK Data Catalogue.xlsx
+
+# Local copy-paste sheets for manually testing the deterministic intake form
+/copy-paste-sheets/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,16 +43,24 @@ gh pr create --base staging --title "PR Title" --body "Description"
 ### Backend (Python/FastAPI)
 - **Source**: `src/dataio/`
 - **API**: `src/dataio/api/` - FastAPI application
-- **Database**: PostgreSQL with SQLAlchemy 2.0+
-- **Auth**: `src/dataio/api/auth/` - Authentication & authorization
-- **Services**: `src/dataio/api/services/` - Business logic layer
-- **Migrations**: `src/dataio/db/migrations/` - SQL migration files
+  - **Routers**: `src/dataio/api/routers/` - `admin.py` (API-key admin endpoints), `user.py`, `validate.py`, `web.py` (session-based web app endpoints, incl. `/admin/*` used by the admin panel)
+  - **Services**: `src/dataio/api/services/` - business logic layer, one service per domain (`admin_dataset_service.py`, `web_admin_service.py`, `chat_service.py`, `filestore_service.py` for S3, etc.)
+  - **Database**: `src/dataio/api/database/` - SQLAlchemy 2.0+ models and query functions (`functions.py`), PostgreSQL
+  - **Auth**: `src/dataio/api/auth/` - Authentication & authorization
+- **Validation library**: `src/dataio/validate/` - standalone Pydantic-based manifest/data validator (`contracts/`, `validators/`, `loaders/`, `registry/`), usable independent of the API
+- **CLI**: `src/dataio/cli/` and **SDK**: `src/dataio/sdk/` - packaged with the PyPI distribution (`dataio-artpark`) for programmatic/CLI access
+- **MCP server**: `src/dataio/mcp/` - exposes dataset-discovery tools to the AI chat assistant
+- **Migrations**: `src/dataio/db/migrations/` - SQL migration files, run via `uv run all-migrations`
 
 ### Frontend (Astro + Preact)
 - **Source**: `web/` - Astro application with TypeScript
 - **Components**: `web/src/components/` - Preact islands for interactivity
+  - `admin/` - admin panel (dataset/raw-dataset import & curation, manifest validation/updates, user & group management)
+  - `datasets/` - public dataset catalogue/browser and detail views
+  - `auth/`, `account/` - OTP/Passkey login, registration, account & API-key management
+  - `chat/` - AI chat assistant UI
 - **Pages**: `web/src/pages/` - Astro pages and layouts
-- **Lib**: `web/src/lib/` - API client, auth helpers, utilities
+- **Lib**: `web/src/lib/` - API client (`api.ts`), shared types (`types.ts`), auth helpers, utilities
 
 ## Web UI Feature
 
@@ -81,6 +89,15 @@ gh pr create --base staging --title "PR Title" --body "Description"
 - `webauthn_challenges` - WebAuthn flow state
 - `user_api_keys` - Self-service API key management
 - Extended `users` table with `email_verified`, `last_login`, `created_at`, `display_name`
+
+## Dataset & Raw Dataset ID Generation
+
+`ds_id` (12 chars, `^[A-Z]{2}\d{4}DS\d{4}$`, enforced by a DB trigger) and `rds_id` (free-form, DB-unique only) are suggested rather than freely chosen, to match the numbering already used in the master Excel catalogue and in S3:
+
+- **`ds_id`** uses a single catalogue-wide counter, independent of collection — `get_next_dataset_serial_number()` / `suggest_next_dataset_id(collection_id)` in `src/dataio/api/database/functions.py`. The numeric suffix is the max across every existing `datasets.ds_id` and `reserved_dataset_ids.ds_id`, plus one; the requested collection only supplies the prefix.
+- **`rds_id`** uses a per-category counter (all collections under one category, e.g. all of `CS0001`, `CS0007`, `CS0026`, share one `CS` counter), in the catalogue's unpadded format (`CSRDS16`) — `suggest_next_raw_dataset_id_for_category(category_id)`.
+- Both are exposed read-only in the admin panel's "Next Available IDs" tab (`DatasetAdminManager.tsx`) via `GET /admin/datasets/next-id-number` and `GET /admin/raw-datasets/suggest-id-by-category` — nothing is created or reserved by looking one up.
+- `reserved_dataset_ids` lets an id be pre-claimed (e.g. for out-of-band coordination) without a `datasets` row existing yet; the suggestion functions factor reserved ids in so they don't get handed out again.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # dataio-artpark
 
-> [!IMPORTANT]
-> This README is outdated and yet to be updated.
+Dataio is a Postgres + FastAPI based Dataset Management System (DMS) built by the Data Science Innovation Hub, ARTPARK, for cataloguing, validating, and distributing datasets. It ships as three things from one repo:
 
-Dataio is a Postgres and FASTAPI based Dataset Management System (DMS) for users to access and manage datasets distributed by the Data Science Innovation Hub, ARTPARK. The scaffolding can be used to build a similar system for your own datasets.
+- A **Python package** (`dataio-artpark` on PyPI) with a CLI, an SDK, and a standalone manifest-validation library (`dataio.validate`) that can be reused outside this project.
+- A **FastAPI backend** (`src/dataio/api/`) serving both the programmatic API and a session-based web application API.
+- An **Astro + Preact web app** (`web/`) — the admin panel and public dataset catalogue/browser.
 
 You can find the documentation for the project [here](https://dataio.artpark.ai), and we're also on PyPI [here](https://pypi.org/project/dataio-artpark/).
 
+For contributor/agent workflow conventions (git workflow, environment variables, code style), see [AGENTS.md](AGENTS.md).
+
+## Features
+
+- **Dataset catalogue** — browse, search, and download versioned datasets with per-table data dictionaries, manifests, and README documentation, gated by access level.
+- **Admin panel** (`web/src/components/admin/`) — import/curate datasets and raw datasets, manage manifests, run manifest validation, and manage users/groups/roles.
+- **Dataset & raw dataset ID generation** — `ds_id` is assigned from a single catalogue-wide counter and `rds_id` from a per-category counter, matching the numbering used in the master Excel catalogue and S3. See `suggest_next_dataset_id` / `suggest_next_raw_dataset_id_for_category` in `src/dataio/api/database/functions.py`, and the "Next Available IDs" tool in the admin panel.
+- **Manifest validation** (`dataio.validate`) — a standalone Pydantic-based library that validates a dataset's `metadata.yaml` + CSV/GeoJSON data against a versioned schema contract (tabular and geojson dataset kinds), independent of the API.
+- **Auth** — passwordless web login via Email OTP or Passkey (WebAuthn), plus API-key auth for programmatic/SDK access.
+- **AI chat assistant** (`/chat`) — an MCP-backed assistant that helps users discover datasets, backed by AWS Bedrock or OpenRouter.
+
 ## Installation
 
-Install the project using pip:
+Install the Python package using pip:
 
 ```bash
 pip install dataio-artpark
@@ -23,28 +35,45 @@ uv add dataio-artpark
 
 ## Development
 
-We use uv to manage the project. Clone the repository and run:
+We use uv to manage the Python project. Clone the repository and run:
 
 ```bash
-uv sync
+uv sync --group api
 ```
 
-## How to set up the local dev environment.
+### Backend
 
-Run below command to set up the DB. API keys for users will be generated in the db/init/data_inserts folder
+Set up the local database (API keys for seeded users are generated in `db/init/data_inserts`):
 
-```
+```bash
 bash ./src/dataio/db/init/recreate_full.sh
 ```
 
-Starting the API Server
+Apply any new migrations:
 
+```bash
+uv run all-migrations
 ```
+
+Start the API server:
+
+```bash
 uv run fastapi dev src/dataio/api
 ```
 
-To start with logging & autoreload enabled
+or, with logging and autoreload:
 
-```
+```bash
 uvicorn src.dataio.api.main:app --log-config log_config.yml --reload
 ```
+
+### Frontend
+
+```bash
+cd web
+npm install
+npm run dev      # dev server
+npm run build    # astro check + production build
+```
+
+See [AGENTS.md](AGENTS.md) for required environment variables (backend `.env` and `web/.env`), the full project structure, and git/PR conventions.

--- a/src/dataio/api/database/enums.py
+++ b/src/dataio/api/database/enums.py
@@ -54,3 +54,10 @@ class ResourceType(str, enum.Enum):
     GROUP = "GROUP"
     BUCKET = "BUCKET"
     WEATHER_DATA_API = "WEATHER_DATA_API"
+
+
+class DatasetManifestDraftStatus(str, enum.Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    FLAGGED = "flagged"

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 import logging
 import re
+import uuid
 from sqlalchemy.orm import joinedload
 import bcrypt
 import secrets
@@ -9,7 +10,7 @@ from sqlalchemy import select
 from datetime import datetime, timedelta
 
 from dataio.api.database.config import Session
-from dataio.api.database.enums import ResourceType
+from dataio.api.database.enums import ResourceType, DatasetManifestDraftStatus
 
 from dataio.api.database.models import (
     Dataset,
@@ -26,8 +27,10 @@ from dataio.api.database.models import (
     RawDataset,
     DatasetRawDataset,
     ReservedDatasetID,
+    ReservedRawDatasetID,
     Region,
     RateLimit,
+    DatasetManifestDraft,
 )
 from dataio.api.auth.permissions import determine_highest_permission
 from dataio.api.models import (
@@ -176,6 +179,283 @@ def delete_reserved_dataset_id(ds_id: str):
         raise
     finally:
         session.close()
+
+
+def check_if_raw_dataset_exists(rds_id: str) -> bool:
+    session = Session()
+    try:
+        raw_dataset = session.query(RawDataset).filter(RawDataset.rds_id == rds_id).first()
+        return raw_dataset is not None
+    except Exception as e:
+        logger.error(f"Error checking if raw dataset exists: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def create_reserved_raw_dataset_id(rds_id: str, category_id: str | None, note: str | None, reserved_by: str):
+    """Mirrors create_reserved_dataset_id, for rds_id. Called immediately
+    after resolving a suggested rds_id (e.g. in draft_service.generate_draft)
+    so two concurrent callers in the same category can't be handed the same
+    suggestion - suggest_next_raw_dataset_id_for_category folds these
+    reservations into its max-suffix computation.
+    """
+    session = Session()
+    try:
+        if check_if_raw_dataset_exists(rds_id):
+            raise ValueError(f"Raw dataset with ID {rds_id} already exists")
+        existing = session.query(ReservedRawDatasetID).filter(ReservedRawDatasetID.rds_id == rds_id).first()
+        if existing:
+            raise ValueError(f"Raw dataset ID {rds_id} is already reserved")
+        reservation = ReservedRawDatasetID(
+            rds_id=rds_id,
+            category_id=category_id,
+            note=note,
+            reserved_by=reserved_by,
+        )
+        session.add(reservation)
+        session.commit()
+        session.refresh(reservation)
+        return reservation
+    except Exception as e:
+        logger.error(f"Error creating reserved raw dataset ID: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def delete_reserved_raw_dataset_id(rds_id: str):
+    session = Session()
+    try:
+        reservation = session.query(ReservedRawDatasetID).filter(ReservedRawDatasetID.rds_id == rds_id).first()
+        if not reservation:
+            raise ValueError(f"Reserved raw dataset ID {rds_id} not found")
+        session.delete(reservation)
+        session.commit()
+    except Exception as e:
+        logger.error(f"Error deleting reserved raw dataset ID: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def _coerce_draft_id(draft_id) -> uuid.UUID:
+    return draft_id if isinstance(draft_id, uuid.UUID) else uuid.UUID(str(draft_id))
+
+
+def create_manifest_draft(
+    *,
+    collection_id: str,
+    category_id: str,
+    source_csv_path: str,
+    draft_yaml: str,
+    draft_json: dict,
+    llm_model_id: str,
+    created_by: str,
+    dataset_id: str | None = None,
+    digitization_log_path: str | None = None,
+    raw_dataset_id: str | None = None,
+    flagged_fields: list | None = None,
+    validation_result: dict | None = None,
+    llm_prompt_tokens: int | None = None,
+    llm_completion_tokens: int | None = None,
+    superseded_by_draft_id: str | None = None,
+    session=None,
+):
+    """Create a pending manifest draft row. Regenerating a single flagged
+    field should call this again (with superseded_by_draft_id set to the
+    original draft) rather than mutating an existing row in place, so the
+    review history stays intact.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = DatasetManifestDraft(
+            dataset_id=dataset_id,
+            collection_id=collection_id,
+            category_id=category_id,
+            source_csv_path=source_csv_path,
+            digitization_log_path=digitization_log_path,
+            raw_dataset_id=raw_dataset_id,
+            status=DatasetManifestDraftStatus.PENDING,
+            draft_yaml=draft_yaml,
+            draft_json=draft_json,
+            flagged_fields=flagged_fields or [],
+            validation_result=validation_result,
+            llm_model_id=llm_model_id,
+            llm_prompt_tokens=llm_prompt_tokens,
+            llm_completion_tokens=llm_completion_tokens,
+            created_by=created_by,
+            superseded_by_draft_id=_coerce_draft_id(superseded_by_draft_id) if superseded_by_draft_id else None,
+        )
+        session.add(draft)
+        session.commit()
+        session.refresh(draft)
+        return draft
+    except Exception as e:
+        logger.error(f"Error creating manifest draft: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
+def get_manifest_draft(draft_id, session=None):
+    owns_session = session is None
+    session = session or Session()
+    try:
+        return (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+    except Exception as e:
+        logger.error(f"Error fetching manifest draft {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
+def list_manifest_drafts(status: str | None = None, dataset_id: str | None = None, limit: int = 50, offset: int = 0):
+    session = Session()
+    try:
+        query = session.query(DatasetManifestDraft)
+        if status:
+            query = query.filter(DatasetManifestDraft.status == DatasetManifestDraftStatus(status))
+        if dataset_id:
+            query = query.filter(DatasetManifestDraft.dataset_id == dataset_id)
+        total = query.count()
+        rows = query.order_by(DatasetManifestDraft.created_at.desc()).offset(offset).limit(limit).all()
+        return rows, total
+    except Exception as e:
+        logger.error(f"Error listing manifest drafts: {str(e)}")
+        raise
+    finally:
+        session.close()
+
+
+def update_manifest_draft_status(
+    draft_id,
+    status: str,
+    *,
+    reviewed_by: str | None = None,
+    dataset_id: str | None = None,
+    validation_result: dict | None = None,
+    session=None,
+):
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+        if not draft:
+            raise ValueError(f"Manifest draft {draft_id} not found")
+        draft.status = DatasetManifestDraftStatus(status)
+        if reviewed_by is not None:
+            draft.reviewed_by = reviewed_by
+            draft.reviewed_at = datetime.utcnow()
+        if dataset_id is not None:
+            draft.dataset_id = dataset_id
+        if validation_result is not None:
+            draft.validation_result = validation_result
+        session.commit()
+        session.refresh(draft)
+        return draft
+    except Exception as e:
+        logger.error(f"Error updating manifest draft {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
+def flag_manifest_draft_field(draft_id, field_path: str, reason: str, flagged_by: str, session=None):
+    """Appends one entry to a draft's flagged_fields, sets its status to
+    'flagged', and records a matching reviewer note - the one place a
+    curator marks a specific field as needing attention/regeneration.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+        if not draft:
+            raise ValueError(f"Manifest draft {draft_id} not found")
+        draft.flagged_fields = [*(draft.flagged_fields or []), {"field": field_path, "reason": reason}]
+        draft.reviewer_notes = [*(draft.reviewer_notes or []), {"field": field_path, "note": reason, "by": flagged_by}]
+        draft.status = DatasetManifestDraftStatus.FLAGGED
+        session.commit()
+        session.refresh(draft)
+        return draft
+    except Exception as e:
+        logger.error(f"Error flagging field on manifest draft {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
+def append_manifest_draft_note(draft_id, note: dict, session=None):
+    """Append one reviewer note (e.g. {"field": "...", "note": "...", "by": "...", "at": "..."})
+    to a draft's reviewer_notes array.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+        if not draft:
+            raise ValueError(f"Manifest draft {draft_id} not found")
+        draft.reviewer_notes = [*(draft.reviewer_notes or []), note]
+        session.commit()
+        session.refresh(draft)
+        return draft
+    except Exception as e:
+        logger.error(f"Error appending note to manifest draft {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
+def delete_manifest_draft(draft_id, session=None):
+    """Deletes a draft row outright - this only removes the staging record,
+    never anything already approved/persisted (that lives in filestore/the
+    datasets table, untouched). Superseding drafts that reference this one
+    via superseded_by_draft_id are unlinked first rather than cascade-deleted,
+    so their own history isn't silently destroyed.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+        if not draft:
+            raise ValueError(f"Manifest draft {draft_id} not found")
+        session.query(DatasetManifestDraft).filter(
+            DatasetManifestDraft.superseded_by_draft_id == draft.draft_id
+        ).update({"superseded_by_draft_id": None})
+        session.delete(draft)
+        session.commit()
+    except Exception as e:
+        logger.error(f"Error deleting manifest draft {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
 
 
 def update_dataset_manifest_cache(
@@ -561,16 +841,19 @@ def suggest_next_raw_dataset_id_for_category(category_id: str, session=None) -> 
 
     Also folds in rds_ids still stored in the older per-collection format
     (e.g. CS0002RDS0003) so a category that already has raw datasets under
-    the old scheme doesn't restart its counter from 1 and collide with them.
+    the old scheme doesn't restart its counter from 1 and collide with them,
+    and folds in reserved_raw_dataset_ids so an id reserved (but not yet
+    turned into a real RawDataset row) isn't suggested again.
     """
     owns_session = session is None
     session = session or Session()
     try:
         existing_ids = session.query(RawDataset.rds_id).all()
+        reserved_ids = session.query(ReservedRawDatasetID.rds_id).all()
         max_suffix = 0
         new_format_pattern = re.compile(rf"^{re.escape(category_id)}RDS(\d+)$")
         legacy_format_pattern = re.compile(rf"^{re.escape(category_id)}\d{{4}}RDS(\d{{4}})$")
-        for (rds_id,) in existing_ids:
+        for (rds_id,) in [*existing_ids, *reserved_ids]:
             rds_id = rds_id or ""
             match = new_format_pattern.match(rds_id) or legacy_format_pattern.match(rds_id)
             if match:

--- a/src/dataio/api/database/functions.py
+++ b/src/dataio/api/database/functions.py
@@ -373,6 +373,44 @@ def update_manifest_draft_status(
             session.close()
 
 
+def update_manifest_draft_content(
+    draft_id,
+    *,
+    draft_yaml: str,
+    draft_json: dict,
+    validation_result: dict | None = None,
+    session=None,
+):
+    """Overwrites a draft's manifest content in place (curator-edited YAML,
+    see draft_review_service.update_draft_content) - unlike
+    update_manifest_draft_status, this never touches status/reviewed_by,
+    since editing content is independent of the review decision.
+    """
+    owns_session = session is None
+    session = session or Session()
+    try:
+        draft = (
+            session.query(DatasetManifestDraft)
+            .filter(DatasetManifestDraft.draft_id == _coerce_draft_id(draft_id))
+            .first()
+        )
+        if not draft:
+            raise ValueError(f"Manifest draft {draft_id} not found")
+        draft.draft_yaml = draft_yaml
+        draft.draft_json = draft_json
+        if validation_result is not None:
+            draft.validation_result = validation_result
+        session.commit()
+        session.refresh(draft)
+        return draft
+    except Exception as e:
+        logger.error(f"Error updating manifest draft content {draft_id}: {str(e)}")
+        raise
+    finally:
+        if owns_session:
+            session.close()
+
+
 def flag_manifest_draft_field(draft_id, field_path: str, reason: str, flagged_by: str, session=None):
     """Appends one entry to a draft's flagged_fields, sets its status to
     'flagged', and records a matching reviewer note - the one place a

--- a/src/dataio/api/database/models.py
+++ b/src/dataio/api/database/models.py
@@ -20,6 +20,7 @@ from dataio.api.database.enums import (
     SpatialResolution,
     TemporalResolution,
     ResourceType,
+    DatasetManifestDraftStatus,
 )
 
 Base = declarative_base()
@@ -109,6 +110,17 @@ class ReservedDatasetID(Base):
     id = Column(Integer, primary_key=True)
     ds_id = Column(Text, nullable=False, unique=True)
     collection_id = Column(Text, nullable=True)
+    note = Column(Text, nullable=True)
+    reserved_by = Column(Text, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class ReservedRawDatasetID(Base):
+    __tablename__ = "reserved_raw_dataset_ids"
+
+    id = Column(Integer, primary_key=True)
+    rds_id = Column(Text, nullable=False, unique=True)
+    category_id = Column(Text, nullable=True)
     note = Column(Text, nullable=True)
     reserved_by = Column(Text, nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -383,3 +395,53 @@ class ChatMessage(Base):
 
     # Relationship
     session = relationship("ChatSession", back_populates="messages")
+
+
+class DatasetManifestDraft(Base):
+    """LLM-drafted metadata.yaml, pending curator review/approval.
+
+    Staging area only. As of now, approving a draft (DraftReviewService.
+    approve_draft) only flips its status - it does not write anything to
+    filestore/Postgres itself. A curator downloads the approved draft_yaml
+    and re-imports it through the existing manifest-upload path (see
+    AdminDatasetService._validate_and_persist_manifest), which is what
+    actually validates and persists it. This table never becomes a second
+    source of truth for the live manifest, but "approve" alone is not
+    sufficient to make a draft live.
+    """
+
+    __tablename__ = "dataset_manifest_drafts"
+
+    draft_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    dataset_id = Column(Text, nullable=True)
+    collection_id = Column(Text, nullable=False)
+    category_id = Column(Text, nullable=False)
+    source_csv_path = Column(Text, nullable=False)
+    digitization_log_path = Column(Text, nullable=True)
+    # The resolved raw_dataset rds_id, tracked here rather than inside
+    # draft_json/draft_yaml - real metadata.yaml files never contain a
+    # raw_dataset/rds_id field, that belongs only in info.yml.
+    raw_dataset_id = Column(Text, nullable=True)
+    # values_callable is required here (unlike the other SQLEnum columns in
+    # this file): DatasetManifestDraftStatus's member names are uppercase
+    # but its values are lowercase to match the Postgres enum type
+    # (dataset_manifest_draft_status), and SQLAlchemy's Enum binds by
+    # .name, not .value, unless told otherwise.
+    status = Column(
+        SQLEnum(DatasetManifestDraftStatus, values_callable=lambda enum_cls: [e.value for e in enum_cls]),
+        nullable=False,
+        default=DatasetManifestDraftStatus.PENDING,
+    )
+    draft_yaml = Column(Text, nullable=False)
+    draft_json = Column(JSONB, nullable=False)
+    flagged_fields = Column(JSONB, nullable=False, default=list)
+    reviewer_notes = Column(JSONB, nullable=False, default=list)
+    validation_result = Column(JSONB, nullable=True)
+    llm_model_id = Column(Text, nullable=False)
+    llm_prompt_tokens = Column(Integer, nullable=True)
+    llm_completion_tokens = Column(Integer, nullable=True)
+    created_by = Column(Text, ForeignKey("users.email"), nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    reviewed_by = Column(Text, ForeignKey("users.email"), nullable=True)
+    reviewed_at = Column(DateTime, nullable=True)
+    superseded_by_draft_id = Column(UUID(as_uuid=True), ForeignKey("dataset_manifest_drafts.draft_id"), nullable=True)

--- a/src/dataio/api/database/rds_id_helpers.py
+++ b/src/dataio/api/database/rds_id_helpers.py
@@ -1,0 +1,36 @@
+import re
+
+from dataio.api.database.functions import suggest_next_raw_dataset_id_for_category
+
+
+def resolve_category_id(meta: dict) -> str:
+    """Pull the category prefix (e.g. "CS") out of a metadata.yaml dict.
+
+    Prefers the explicit category.ID field. Falls back to stripping the
+    trailing collection sequence number off collection.ID (e.g. "CS0007" ->
+    "CS"), matching suggest_next_raw_dataset_id's own fallback when a
+    Collection row isn't available.
+    """
+    category = meta.get("category") or {}
+    category_id = str(category.get("ID", "")).strip()
+    if category_id:
+        return category_id
+
+    collection = meta.get("collection") or {}
+    collection_id = str(collection.get("ID", "")).strip()
+    return re.sub(r"\d+$", "", collection_id)
+
+
+def resolve_rds_id(meta: dict) -> str:
+    """The single source of truth for raw_dataset.rds_id: the DB-driven
+    per-category counter (suggest_next_raw_dataset_id_for_category), not a
+    sibling-info.yml scan. See metadata-architecture memo, Limitations ->
+    "Two competing raw-dataset-ID generators" for why the old scan is retired.
+    """
+    category_id = resolve_category_id(meta)
+    if not category_id:
+        raise ValueError(
+            "Cannot resolve rds_id: metadata has no category.ID and no "
+            "collection.ID to fall back to."
+        )
+    return suggest_next_raw_dataset_id_for_category(category_id)

--- a/src/dataio/api/database/temporal_resolution_mapping.py
+++ b/src/dataio/api/database/temporal_resolution_mapping.py
@@ -1,0 +1,67 @@
+from dataio.api.database.enums import TemporalResolution
+
+# Free-text temporalResolution values seen in metadata.yaml, mapped onto the
+# DB's TemporalResolution enum. Several of these (quinquennial, decadal, ...)
+# collapse lossily into YEAR because the enum has no coarser-than-YEAR
+# member - callers must record the original text in `comments` when that
+# happens, rather than silently discarding it. See metadata-architecture
+# memo, Limitations -> "temporal_resolution has no mapping table".
+TEMPORAL_RESOLUTION_MAP: dict[str, TemporalResolution] = {
+    "year": TemporalResolution.YEAR,
+    "yearly": TemporalResolution.YEAR,
+    "annual": TemporalResolution.YEAR,
+    "annually": TemporalResolution.YEAR,
+    "quinquennial": TemporalResolution.YEAR,
+    "quinquennium": TemporalResolution.YEAR,
+    "5-year": TemporalResolution.YEAR,
+    "5-yearly": TemporalResolution.YEAR,
+    "decadal": TemporalResolution.YEAR,
+    "decennial": TemporalResolution.YEAR,
+    "month": TemporalResolution.MONTH,
+    "monthly": TemporalResolution.MONTH,
+    "week": TemporalResolution.WEEK,
+    "weekly": TemporalResolution.WEEK,
+    "day": TemporalResolution.DATE,
+    "daily": TemporalResolution.DATE,
+    "date": TemporalResolution.DATE,
+    "hour": TemporalResolution.HOUR,
+    "hourly": TemporalResolution.HOUR,
+    "minute": TemporalResolution.MINUTE,
+    "second": TemporalResolution.SECOND,
+    "none": TemporalResolution.NONE,
+    "static": TemporalResolution.NONE,
+    "n/a": TemporalResolution.NONE,
+}
+
+# Values that map onto a coarser enum member than what they actually mean -
+# resolve_temporal_resolution's caller should note the original text
+# somewhere (e.g. metadata comments) when the resolved key is in here.
+LOSSY_TEMPORAL_RESOLUTIONS = {
+    "quinquennial", "quinquennium", "5-year", "5-yearly", "decadal", "decennial",
+}
+
+
+def resolve_temporal_resolution(raw: str) -> str:
+    """Map free-text temporalResolution onto a valid TemporalResolution enum
+    value. Raises instead of the old str(...).upper() behavior, which
+    silently coerced anything (e.g. "quinquennial" -> the invalid literal
+    "QUINQUENNIAL") without ever checking it against the real enum.
+    """
+    key = str(raw or "").strip().lower()
+    mapped = TEMPORAL_RESOLUTION_MAP.get(key)
+    if mapped is None:
+        valid_values = [e.value for e in TemporalResolution]
+        raise ValueError(
+            f"Unrecognized temporalResolution '{raw}'. Extend "
+            f"TEMPORAL_RESOLUTION_MAP in {__name__}, or fix the source "
+            f"metadata.yaml. Valid enum values: {valid_values}"
+        )
+    return mapped.value
+
+
+def is_lossy_temporal_resolution(raw: str) -> bool:
+    """Whether `raw` collapses into a coarser enum member than it actually
+    means (e.g. "quinquennial" -> YEAR) - callers should preserve the
+    original text (e.g. in a comments field) when this is True.
+    """
+    return str(raw or "").strip().lower() in LOSSY_TEMPORAL_RESOLUTIONS

--- a/src/dataio/api/models.py
+++ b/src/dataio/api/models.py
@@ -107,6 +107,12 @@ class ManifestDraftEdit(BaseModel):
     draft_yaml: str = Field(..., description="Full replacement manifest YAML, curator-edited")
 
 
+class ManifestDraftInfoYamlRequest(BaseModel):
+    access_level: AccessLevel = Field(
+        ..., description="Access level for the generated info.yml - not derivable from the draft"
+    )
+
+
 class ClassifyColumnsRequest(BaseModel):
     table_name: str = Field(..., description="Name of the table (CSV filename stem)")
     column_names: List[str] = Field(

--- a/src/dataio/api/models.py
+++ b/src/dataio/api/models.py
@@ -94,6 +94,15 @@ class DatasetDocumentationUpdate(BaseModel):
     )
 
 
+class ManifestDraftReject(BaseModel):
+    reason: Optional[str] = Field(None, description="Why this draft was rejected")
+
+
+class ManifestDraftFlagField(BaseModel):
+    field_path: str = Field(..., description="Dotted path or column name being flagged")
+    note: str = Field(..., description="Why this field needs curator attention")
+
+
 class User(BaseModel):
     email: str
     is_group: bool

--- a/src/dataio/api/models.py
+++ b/src/dataio/api/models.py
@@ -103,6 +103,17 @@ class ManifestDraftFlagField(BaseModel):
     note: str = Field(..., description="Why this field needs curator attention")
 
 
+class ManifestDraftEdit(BaseModel):
+    draft_yaml: str = Field(..., description="Full replacement manifest YAML, curator-edited")
+
+
+class ClassifyColumnsRequest(BaseModel):
+    table_name: str = Field(..., description="Name of the table (CSV filename stem)")
+    column_names: List[str] = Field(
+        ..., description="Column names read from the CSV header - schema only"
+    )
+
+
 class User(BaseModel):
     email: str
     is_group: bool

--- a/src/dataio/api/models.py
+++ b/src/dataio/api/models.py
@@ -113,6 +113,15 @@ class ManifestDraftInfoYamlRequest(BaseModel):
     )
 
 
+class ManifestDraftImportRequest(BaseModel):
+    access_level: AccessLevel = Field(
+        ..., description="Access level for the info.yml generated as part of the import"
+    )
+    bucket_type: VersionType = Field(
+        default=VersionType.STANDARDISED, description="Filestore bucket to upload the tables into"
+    )
+
+
 class ClassifyColumnsRequest(BaseModel):
     table_name: str = Field(..., description="Name of the table (CSV filename stem)")
     column_names: List[str] = Field(

--- a/src/dataio/api/reference_data/canonical_enum_registry.yaml
+++ b/src/dataio/api/reference_data/canonical_enum_registry.yaml
@@ -1,0 +1,50 @@
+# Fixed cross-dataset canonicalEnumDefinitions registries every real
+# dataset in this system reuses verbatim - lifted out of draft_prompt.py's
+# LLM instruction ("ESTABLISHED REGISTRY... reuse it verbatim, do not
+# invent a new block or ID") into real structured data, so a deterministic
+# generator can look these up by column-name match instead of an LLM
+# recalling the instruction. See field_inference.lookup_canonical_enum_definitions.
+#
+# `matchColumnNameContains` is checked against the column's bare (last
+# dotted segment) name, case-insensitively. Add new registries here as new
+# cross-dataset concepts are established - never change an existing `id`
+# or `block` name, since datasets already reference these verbatim.
+schemaVersion: "1.0"
+registries:
+  - id: INL-98
+    block: canonicalSpecies
+    matchColumnNameContains: [species]
+    definition:
+      description: >-
+        Cross-dataset canonical species vocabulary (INL-98). Resolve
+        species series by this canonical key rather than dataset-local
+        literal strings.
+      values:
+        cattle: {grain: leaf}
+        buffalo: {grain: leaf}
+        goat: {grain: leaf}
+        sheep: {grain: leaf}
+        pig: {grain: leaf}
+        poultry: {grain: leaf}
+        bovine: {grain: group, components: [cattle, buffalo]}
+        ovine_and_other_mammals: {grain: group, components: [sheep, goat]}
+        others: {grain: residual}
+
+  - id: INL-98
+    block: canonicalBreed
+    matchColumnNameContains: [breed]
+    definition:
+      description: >-
+        Cross-dataset canonical breed vocabulary (INL-98). Census reports
+        the combined grain (crossbred_exotic); milk reports the split
+        grain (exotic, crossbred). For cross-dataset joins, match on
+        canonicalRollup; for fine within-dataset analysis, use canonical.
+      values:
+        crossbred_exotic: {grain: coarse, components: [exotic, crossbred]}
+        exotic: {grain: leaf, rollup: crossbred_exotic}
+        crossbred: {grain: leaf, rollup: crossbred_exotic}
+        indigenous: {grain: leaf}
+        non_descript: {grain: leaf}
+        indigenous_non_descript: {grain: coarse, components: [indigenous, non_descript]}
+        none: {grain: na}
+        unspecified: {grain: unknown}

--- a/src/dataio/api/reference_data/region_history.yaml
+++ b/src/dataio/api/reference_data/region_history.yaml
@@ -1,0 +1,71 @@
+# Curated reference table of known Indian state/UT administrative
+# reorganization events - the deterministic replacement for the LLM
+# drafter's "use your own historical knowledge" instruction
+# (draft_prompt.py RULES item 2, e.g. "Telangana absent from 1997-2012
+# data... part of Andhra Pradesh until 2014"). See region_gap_detector.py,
+# which cross-references this list against a dataset's actual
+# region x year coverage to generate the same kind of `comments` entry
+# deterministically.
+#
+# Extend this list over time as new gaps are found during digitization -
+# a growing, curator-verified asset, not a repeated per-request inference.
+#
+# `region` is the name that appears as a *new* distinct value in the data
+# from `effective_date` onward. `predecessors` are the region name(s) it
+# was carved out of/replaced - data covering years before `effective_date`
+# should show the predecessor(s) instead, not `region`.
+schemaVersion: "1.0"
+events:
+  - region: Telangana
+    event: bifurcated
+    effective_date: "2014-06-02"
+    predecessors: [Andhra Pradesh]
+    note: >-
+      Telangana was carved out of Andhra Pradesh effective 2 June 2014
+      (Andhra Pradesh Reorganisation Act, 2014). Data covering years before
+      2014 will show it as part of Andhra Pradesh, not as a separate entry.
+
+  - region: Chhattisgarh
+    event: bifurcated
+    effective_date: "2000-11-01"
+    predecessors: [Madhya Pradesh]
+    note: >-
+      Chhattisgarh was carved out of Madhya Pradesh effective 1 November
+      2000. Data covering earlier years will show it as part of Madhya
+      Pradesh.
+
+  - region: Jharkhand
+    event: bifurcated
+    effective_date: "2000-11-15"
+    predecessors: [Bihar]
+    note: >-
+      Jharkhand was carved out of Bihar effective 15 November 2000. Data
+      covering earlier years will show it as part of Bihar.
+
+  - region: Uttarakhand
+    event: bifurcated
+    effective_date: "2000-11-09"
+    predecessors: [Uttar Pradesh]
+    note: >-
+      Uttarakhand (initially named Uttaranchal, renamed Uttarakhand in
+      2007) was carved out of Uttar Pradesh effective 9 November 2000.
+      Data covering earlier years will show it as part of Uttar Pradesh.
+
+  - region: Ladakh
+    event: created
+    effective_date: "2019-10-31"
+    predecessors: [Jammu and Kashmir]
+    note: >-
+      Ladakh became a separate union territory, split from the former
+      state of Jammu and Kashmir, effective 31 October 2019 (Jammu and
+      Kashmir Reorganisation Act, 2019). Data covering earlier years will
+      show it as part of Jammu and Kashmir.
+
+  - region: Dadra and Nagar Haveli and Daman and Diu
+    event: merged
+    effective_date: "2020-01-26"
+    predecessors: [Dadra and Nagar Haveli, Daman and Diu]
+    note: >-
+      Dadra and Nagar Haveli and Daman and Diu were merged into a single
+      union territory effective 26 January 2020. Data covering earlier
+      years will show these as two separate entries.

--- a/src/dataio/api/routers/admin.py
+++ b/src/dataio/api/routers/admin.py
@@ -1,10 +1,13 @@
 from fastapi import HTTPException, Depends, APIRouter, Form, UploadFile
 from typing import List
+import json
 import logging
 from dataio.api.auth import get_user, admin_required
 from dataio.api.services import AdminUserManagementService, AdminDatasetService, DraftReviewService
 from dataio.api.models import (
+    ClassifyColumnsRequest,
     DatasetCreate,
+    ManifestDraftEdit,
     ManifestDraftFlagField,
     ManifestDraftReject,
     User,
@@ -202,6 +205,40 @@ async def generate_manifest_draft(
     )
 
 
+@admin_router.post("/manifest-drafts/generate-deterministic", tags=["admin/manifest-drafts"])
+@admin_required
+async def generate_deterministic_manifest_draft(
+    csv_files: List[UploadFile],
+    category_id: str = Form(...),
+    collection_id: str = Form(...),
+    data_owner_name: str = Form(...),
+    curator_input: str = Form(...),
+    created_by: str = Form(None),
+    dataset_id: str = Form(None),
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.generate_deterministic_draft_from_upload(
+        csv_files=csv_files,
+        category_id=category_id,
+        collection_id=collection_id,
+        data_owner_name=data_owner_name,
+        created_by=created_by or user.email,
+        curator_input=json.loads(curator_input),
+        dataset_id=dataset_id,
+    )
+
+
+@admin_router.post("/manifest-drafts/classify-columns", tags=["admin/manifest-drafts"])
+@admin_required
+async def classify_columns(
+    body: ClassifyColumnsRequest,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.classify_columns(column_names=body.column_names)
+
+
 @admin_router.get("/manifest-drafts", tags=["admin/manifest-drafts"])
 @admin_required
 async def list_manifest_drafts(
@@ -265,6 +302,17 @@ async def reject_manifest_draft(
     draft_review_service: DraftReviewService = Depends(DraftReviewService),
 ):
     return draft_review_service.reject_draft(draft_id, user.email, reason=body.reason)
+
+
+@admin_router.put("/manifest-drafts/{draft_id}", tags=["admin/manifest-drafts"])
+@admin_required
+async def update_manifest_draft(
+    draft_id: str,
+    body: ManifestDraftEdit,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.update_draft_content(draft_id, body.draft_yaml)
 
 
 @admin_router.post("/manifest-drafts/{draft_id}/flag-field", tags=["admin/manifest-drafts"])

--- a/src/dataio/api/routers/admin.py
+++ b/src/dataio/api/routers/admin.py
@@ -9,6 +9,7 @@ from dataio.api.models import (
     DatasetCreate,
     ManifestDraftEdit,
     ManifestDraftFlagField,
+    ManifestDraftInfoYamlRequest,
     ManifestDraftReject,
     User,
     UserCreate,
@@ -334,6 +335,17 @@ async def regenerate_manifest_draft(
     draft_review_service: DraftReviewService = Depends(DraftReviewService),
 ):
     return draft_review_service.regenerate_draft(draft_id, user.email)
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/info-yaml", tags=["admin/manifest-drafts"])
+@admin_required
+async def generate_manifest_draft_info_yaml(
+    draft_id: str,
+    body: ManifestDraftInfoYamlRequest,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.generate_info_yaml(draft_id, body.access_level.value)
 
 
 @admin_router.delete(

--- a/src/dataio/api/routers/admin.py
+++ b/src/dataio/api/routers/admin.py
@@ -1,9 +1,12 @@
-from fastapi import HTTPException, Depends, APIRouter, UploadFile
+from fastapi import HTTPException, Depends, APIRouter, Form, UploadFile
+from typing import List
 import logging
 from dataio.api.auth import get_user, admin_required
-from dataio.api.services import AdminUserManagementService, AdminDatasetService
+from dataio.api.services import AdminUserManagementService, AdminDatasetService, DraftReviewService
 from dataio.api.models import (
     DatasetCreate,
+    ManifestDraftFlagField,
+    ManifestDraftReject,
     User,
     UserCreate,
     VersionType,
@@ -168,6 +171,121 @@ async def get_dataset_manifest(
     admin_dataset_service: AdminDatasetService = Depends(AdminDatasetService),
 ):
     return admin_dataset_service.get_dataset_manifest(dataset_id, bucket_type)
+
+
+###
+### MANIFEST DRAFTS (LLM-drafted metadata.yaml, pending curator review)
+###
+
+
+@admin_router.post("/manifest-drafts/generate", tags=["admin/manifest-drafts"])
+@admin_required
+async def generate_manifest_draft(
+    csv_files: List[UploadFile],
+    category_id: str = Form(...),
+    collection_id: str = Form(...),
+    data_owner_name: str = Form(...),
+    created_by: str = Form(None),
+    dataset_id: str = Form(None),
+    digitization_log_file: UploadFile = None,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.generate_draft_from_upload(
+        csv_files=csv_files,
+        category_id=category_id,
+        collection_id=collection_id,
+        data_owner_name=data_owner_name,
+        created_by=created_by or user.email,
+        dataset_id=dataset_id,
+        digitization_log_file=digitization_log_file,
+    )
+
+
+@admin_router.get("/manifest-drafts", tags=["admin/manifest-drafts"])
+@admin_required
+async def list_manifest_drafts(
+    status: str = None,
+    dataset_id: str = None,
+    limit: int = 50,
+    offset: int = 0,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.list_drafts(status=status, dataset_id=dataset_id, limit=limit, offset=offset)
+
+
+@admin_router.get("/manifest-drafts/{draft_id}", tags=["admin/manifest-drafts"])
+@admin_required
+async def get_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.get_draft(draft_id)
+
+
+@admin_router.delete("/manifest-drafts/{draft_id}", tags=["admin/manifest-drafts"])
+@admin_required
+async def delete_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    draft_review_service.delete_draft(draft_id)
+    return {"message": "Manifest draft deleted", "draft_id": draft_id}
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/validate", tags=["admin/manifest-drafts"])
+@admin_required
+async def revalidate_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.revalidate_draft(draft_id)
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/approve", tags=["admin/manifest-drafts"])
+@admin_required
+async def approve_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.approve_draft(draft_id, user.email)
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/reject", tags=["admin/manifest-drafts"])
+@admin_required
+async def reject_manifest_draft(
+    draft_id: str,
+    body: ManifestDraftReject,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.reject_draft(draft_id, user.email, reason=body.reason)
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/flag-field", tags=["admin/manifest-drafts"])
+@admin_required
+async def flag_manifest_draft_field(
+    draft_id: str,
+    body: ManifestDraftFlagField,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.flag_field(draft_id, body.field_path, body.note, user.email)
+
+
+@admin_router.post("/manifest-drafts/{draft_id}/regenerate", tags=["admin/manifest-drafts"])
+@admin_required
+async def regenerate_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_user),
+    draft_review_service: DraftReviewService = Depends(DraftReviewService),
+):
+    return draft_review_service.regenerate_draft(draft_id, user.email)
 
 
 @admin_router.delete(

--- a/src/dataio/api/routers/web.py
+++ b/src/dataio/api/routers/web.py
@@ -39,6 +39,7 @@ from dataio.api.models import (
     DatasetUpdate,
     ManifestDraftEdit,
     ManifestDraftFlagField,
+    ManifestDraftInfoYamlRequest,
     ManifestDraftReject,
     RawDatasetCreate,
     RawDatasetUpdate,
@@ -1758,6 +1759,18 @@ async def web_regenerate_manifest_draft(
     admin_service: WebAdminService = Depends(WebAdminService),
 ):
     return admin_service.regenerate_manifest_draft(user, draft_id)
+
+
+@web_router.post(
+    "/admin/manifest-drafts/{draft_id}/info-yaml", tags=["web-admin/manifest-drafts"]
+)
+async def web_generate_manifest_draft_info_yaml(
+    draft_id: str,
+    body: ManifestDraftInfoYamlRequest,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.generate_manifest_draft_info_yaml(user, draft_id, body.access_level.value)
 
 
 @web_router.get("/admin/documentation-sync", tags=["web-admin/datasets"])

--- a/src/dataio/api/routers/web.py
+++ b/src/dataio/api/routers/web.py
@@ -39,6 +39,7 @@ from dataio.api.models import (
     DatasetUpdate,
     ManifestDraftEdit,
     ManifestDraftFlagField,
+    ManifestDraftImportRequest,
     ManifestDraftInfoYamlRequest,
     ManifestDraftReject,
     RawDatasetCreate,
@@ -1673,6 +1674,19 @@ async def web_classify_columns(
     return admin_service.classify_columns(user, body.column_names)
 
 
+@web_router.post("/admin/manifest-drafts/infer-coverage", tags=["web-admin/manifest-drafts"])
+async def web_infer_dataset_coverage(
+    csv_files: List[UploadFile] = File(...),
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    """Suggests spatialCoverage/spatialResolution/temporalCoverage for the
+    deterministic-draft intake form, from the CSVs' own profiled structure
+    - a starting point the curator reviews and can edit, never silently
+    trusted as final."""
+    return admin_service.infer_dataset_coverage(user, csv_files)
+
+
 @web_router.get("/admin/manifest-drafts", tags=["web-admin/manifest-drafts"])
 async def web_list_manifest_drafts(
     status: Optional[str] = None,
@@ -1771,6 +1785,22 @@ async def web_generate_manifest_draft_info_yaml(
     admin_service: WebAdminService = Depends(WebAdminService),
 ):
     return admin_service.generate_manifest_draft_info_yaml(user, draft_id, body.access_level.value)
+
+
+@web_router.post(
+    "/admin/manifest-drafts/{draft_id}/import", tags=["web-admin/manifest-drafts"]
+)
+async def web_import_dataset_from_draft(
+    draft_id: str,
+    body: ManifestDraftImportRequest,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    """Publishes an approved draft straight to the catalog - the same
+    import_dataset_package pipeline the Import Dataset Package tool uses,
+    driven directly from the draft's own stored fields instead of a manual
+    download/re-upload round-trip."""
+    return admin_service.import_dataset_from_draft(user, draft_id, body.access_level.value, body.bucket_type)
 
 
 @web_router.get("/admin/documentation-sync", tags=["web-admin/datasets"])

--- a/src/dataio/api/routers/web.py
+++ b/src/dataio/api/routers/web.py
@@ -36,6 +36,8 @@ from dataio.api.models import (
     DatasetCreate,
     DatasetDocumentationUpdate,
     DatasetUpdate,
+    ManifestDraftFlagField,
+    ManifestDraftReject,
     RawDatasetCreate,
     RawDatasetUpdate,
 )
@@ -1613,14 +1615,118 @@ async def admin_upsert_dataset_manifest(
     )
 
 
-@web_router.get("/admin/documentation-sync", tags=["web-admin/datasets"])
-async def admin_check_documentation_sync(
-    dataset_id: Optional[str] = None,
+@web_router.post("/admin/manifest-drafts/generate", tags=["web-admin/manifest-drafts"])
+async def web_generate_manifest_draft(
+    csv_files: List[UploadFile] = File(...),
+    category_id: str = Form(...),
+    collection_id: str = Form(...),
+    data_owner_name: str = Form(...),
+    dataset_id: Optional[str] = Form(None),
+    digitization_log_file: Optional[UploadFile] = File(None),
     user: User = Depends(get_current_web_user),
     admin_service: WebAdminService = Depends(WebAdminService),
 ):
-    """Check which datasets have documentation out of sync with filestore."""
-    return admin_service.check_dataset_documentation_sync(user, dataset_id)
+    return admin_service.generate_manifest_draft(
+        user,
+        csv_files,
+        category_id,
+        collection_id,
+        data_owner_name,
+        dataset_id=dataset_id,
+        digitization_log_file=digitization_log_file,
+    )
+
+
+@web_router.get("/admin/manifest-drafts", tags=["web-admin/manifest-drafts"])
+async def web_list_manifest_drafts(
+    status: Optional[str] = None,
+    dataset_id: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.list_manifest_drafts(user, status=status, dataset_id=dataset_id, limit=limit, offset=offset)
+
+
+@web_router.get("/admin/manifest-drafts/{draft_id}", tags=["web-admin/manifest-drafts"])
+async def web_get_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.get_manifest_draft(user, draft_id)
+
+
+@web_router.delete("/admin/manifest-drafts/{draft_id}", tags=["web-admin/manifest-drafts"])
+async def web_delete_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    admin_service.delete_manifest_draft(user, draft_id)
+    return {"message": "Manifest draft deleted", "draft_id": draft_id}
+
+
+@web_router.post("/admin/manifest-drafts/{draft_id}/validate", tags=["web-admin/manifest-drafts"])
+async def web_revalidate_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.revalidate_manifest_draft(user, draft_id)
+
+
+@web_router.post("/admin/manifest-drafts/{draft_id}/approve", tags=["web-admin/manifest-drafts"])
+async def web_approve_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.approve_manifest_draft(user, draft_id)
+
+
+@web_router.post("/admin/manifest-drafts/{draft_id}/reject", tags=["web-admin/manifest-drafts"])
+async def web_reject_manifest_draft(
+    draft_id: str,
+    body: ManifestDraftReject,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.reject_manifest_draft(user, draft_id, reason=body.reason)
+
+
+@web_router.post("/admin/manifest-drafts/{draft_id}/flag-field", tags=["web-admin/manifest-drafts"])
+async def web_flag_manifest_draft_field(
+    draft_id: str,
+    body: ManifestDraftFlagField,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.flag_manifest_draft_field(user, draft_id, body.field_path, body.note)
+
+
+@web_router.post("/admin/manifest-drafts/{draft_id}/regenerate", tags=["web-admin/manifest-drafts"])
+async def web_regenerate_manifest_draft(
+    draft_id: str,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.regenerate_manifest_draft(user, draft_id)
+
+
+@web_router.get("/admin/documentation-sync", tags=["web-admin/datasets"])
+async def admin_check_documentation_sync(
+    dataset_id: Optional[str] = None,
+    check_all: bool = False,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    """Check which datasets have documentation out of sync with filestore.
+    Pass dataset_id for the interactive per-dataset check, or check_all=true
+    for a summary count across every dataset (e.g. the admin overview).
+    """
+    return admin_service.check_dataset_documentation_sync(user, dataset_id, check_all=check_all)
 
 
 @web_router.post("/admin/documentation-sync", tags=["web-admin/datasets"])

--- a/src/dataio/api/routers/web.py
+++ b/src/dataio/api/routers/web.py
@@ -33,9 +33,11 @@ from dataio.api.database.enums import VersionType
 from dataio.api.database.models import User
 from dataio.api.auth.jwt import REFRESH_COOKIE_NAME, get_current_web_user
 from dataio.api.models import (
+    ClassifyColumnsRequest,
     DatasetCreate,
     DatasetDocumentationUpdate,
     DatasetUpdate,
+    ManifestDraftEdit,
     ManifestDraftFlagField,
     ManifestDraftReject,
     RawDatasetCreate,
@@ -1637,6 +1639,39 @@ async def web_generate_manifest_draft(
     )
 
 
+@web_router.post(
+    "/admin/manifest-drafts/generate-deterministic", tags=["web-admin/manifest-drafts"]
+)
+async def web_generate_deterministic_manifest_draft(
+    csv_files: List[UploadFile] = File(...),
+    category_id: str = Form(...),
+    collection_id: str = Form(...),
+    data_owner_name: str = Form(...),
+    curator_input: str = Form(...),
+    dataset_id: Optional[str] = Form(None),
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.generate_deterministic_manifest_draft(
+        user,
+        csv_files,
+        category_id,
+        collection_id,
+        data_owner_name,
+        json.loads(curator_input),
+        dataset_id=dataset_id,
+    )
+
+
+@web_router.post("/admin/manifest-drafts/classify-columns", tags=["web-admin/manifest-drafts"])
+async def web_classify_columns(
+    body: ClassifyColumnsRequest,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.classify_columns(user, body.column_names)
+
+
 @web_router.get("/admin/manifest-drafts", tags=["web-admin/manifest-drafts"])
 async def web_list_manifest_drafts(
     status: Optional[str] = None,
@@ -1694,6 +1729,16 @@ async def web_reject_manifest_draft(
     admin_service: WebAdminService = Depends(WebAdminService),
 ):
     return admin_service.reject_manifest_draft(user, draft_id, reason=body.reason)
+
+
+@web_router.put("/admin/manifest-drafts/{draft_id}", tags=["web-admin/manifest-drafts"])
+async def web_update_manifest_draft(
+    draft_id: str,
+    body: ManifestDraftEdit,
+    user: User = Depends(get_current_web_user),
+    admin_service: WebAdminService = Depends(WebAdminService),
+):
+    return admin_service.update_manifest_draft_content(user, draft_id, body.draft_yaml)
 
 
 @web_router.post("/admin/manifest-drafts/{draft_id}/flag-field", tags=["web-admin/manifest-drafts"])

--- a/src/dataio/api/services/__init__.py
+++ b/src/dataio/api/services/__init__.py
@@ -2,10 +2,12 @@ from .user_service import UserService
 from .filestore_service import FilestoreService
 from .admin_user_management_service import AdminUserManagementService
 from .admin_dataset_service import AdminDatasetService
+from .draft_review_service import DraftReviewService
 
 __all__ = [
     "UserService",
     "FilestoreService",
     "AdminUserManagementService",
     "AdminDatasetService",
+    "DraftReviewService",
 ]

--- a/src/dataio/api/services/admin_dataset_service.py
+++ b/src/dataio/api/services/admin_dataset_service.py
@@ -370,6 +370,88 @@ class AdminDatasetService(BaseService):
                 status_code=500, detail="Failed to list dataset tables. Contact support."
             ) from e
 
+    def _validate_and_persist_manifest(
+        self,
+        dataset_id: str,
+        bucket_type: VersionType,
+        manifest_text: str,
+        parsed_manifest: dict,
+        updated_by: str,
+    ):
+        """Validates a manifest against the dataset's stored data files,
+        then writes it to filestore + the DB manifest cache and refreshes
+        doc-sync. Raises ValidationError/HTTPException on failure.
+
+        Used by the direct manifest-upload endpoint. An LLM draft that has
+        been through DraftReviewService.approve_draft has NOT gone through
+        this method yet - approval only flips the draft's status. A curator
+        must download the approved draft_yaml and re-upload it through the
+        normal manifest-upload flow (which does call this) before it's
+        actually validated and persisted. If the draft-approval path is ever
+        wired to call this directly instead, this docstring should say so.
+        """
+        dataset_kind = parsed_manifest.get("datasetKind")
+        if not dataset_kind:
+            raise ValidationError("Manifest must define datasetKind")
+        try:
+            dataset_kind_enum = DatasetKind(dataset_kind)
+        except ValueError as e:
+            raise ValidationError(f"Unsupported datasetKind '{dataset_kind}'") from e
+
+        validation_request = ValidationRequest(
+            dataset_kind=dataset_kind_enum,
+            manifest_source=manifest_text,
+            validate_data=True,
+        )
+        if dataset_kind_enum == DatasetKind.TABULAR:
+            validation_request.data_files = (
+                self.filestore_service.get_tabular_validation_sources(
+                    dataset_id,
+                    bucket_type,
+                )
+            )
+            if not validation_request.data_files:
+                raise ValidationError(
+                    "Cannot upload manifest until tabular data files exist in filestore"
+                )
+        elif dataset_kind_enum == DatasetKind.GEOJSON:
+            validation_request.data = self.filestore_service.get_geojson_validation_source(
+                dataset_id,
+                bucket_type,
+            )
+
+        validation_result = self.validation_service.validate(validation_request)
+        if validation_result.status == "fail":
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": "Manifest and stored data validation failed",
+                    "findings": [
+                        finding.model_dump() for finding in validation_result.findings
+                    ],
+                },
+            )
+
+        self.filestore_service.upload_manifest(
+            dataset_id=dataset_id,
+            version_type=bucket_type,
+            manifest_yaml=manifest_text,
+            manifest_json=parsed_manifest,
+        )
+        database.update_dataset_manifest_cache(
+            dataset_id,
+            manifest_yaml=manifest_text,
+            manifest_json=parsed_manifest,
+            updated_by=updated_by,
+        )
+        self.refresh_dataset_documentation_cache(dataset_id)
+        return {
+            "message": "Manifest uploaded successfully",
+            "dataset_id": dataset_id,
+            "bucket_type": bucket_type.value,
+            "manifest_json": parsed_manifest,
+        }
+
     def upsert_dataset_manifest(
         self,
         dataset_id: str,
@@ -386,67 +468,9 @@ class AdminDatasetService(BaseService):
             if not isinstance(parsed_manifest, dict):
                 raise ValidationError("Manifest must deserialize to an object")
 
-            dataset_kind = parsed_manifest.get("datasetKind")
-            if not dataset_kind:
-                raise ValidationError("Manifest must define datasetKind")
-            try:
-                dataset_kind_enum = DatasetKind(dataset_kind)
-            except ValueError as e:
-                raise ValidationError(f"Unsupported datasetKind '{dataset_kind}'") from e
-
-            validation_request = ValidationRequest(
-                dataset_kind=dataset_kind_enum,
-                manifest_source=manifest_text,
-                validate_data=True,
+            return self._validate_and_persist_manifest(
+                dataset_id, bucket_type, manifest_text, parsed_manifest, updated_by
             )
-            if dataset_kind_enum == DatasetKind.TABULAR:
-                validation_request.data_files = (
-                    self.filestore_service.get_tabular_validation_sources(
-                        dataset_id,
-                        bucket_type,
-                    )
-                )
-                if not validation_request.data_files:
-                    raise ValidationError(
-                        "Cannot upload manifest until tabular data files exist in filestore"
-                    )
-            elif dataset_kind_enum == DatasetKind.GEOJSON:
-                validation_request.data = self.filestore_service.get_geojson_validation_source(
-                    dataset_id,
-                    bucket_type,
-                )
-
-            validation_result = self.validation_service.validate(validation_request)
-            if validation_result.status == "fail":
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "message": "Manifest and stored data validation failed",
-                        "findings": [
-                            finding.model_dump() for finding in validation_result.findings
-                        ],
-                    },
-                )
-
-            self.filestore_service.upload_manifest(
-                dataset_id=dataset_id,
-                version_type=bucket_type,
-                manifest_yaml=manifest_text,
-                manifest_json=parsed_manifest,
-            )
-            database.update_dataset_manifest_cache(
-                dataset_id,
-                manifest_yaml=manifest_text,
-                manifest_json=parsed_manifest,
-                updated_by=updated_by,
-            )
-            self.refresh_dataset_documentation_cache(dataset_id)
-            return {
-                "message": "Manifest uploaded successfully",
-                "dataset_id": dataset_id,
-                "bucket_type": bucket_type.value,
-                "manifest_json": parsed_manifest,
-            }
         except HTTPException:
             raise
         except ValidationError as e:
@@ -490,10 +514,16 @@ class AdminDatasetService(BaseService):
                 detail="Failed to delete dataset version file. Contact support.",
             ) from e
 
-    def check_dataset_documentation_sync(self, dataset_id: str | None = None):
+    def check_dataset_documentation_sync(self, dataset_id: str | None = None, *, check_all: bool = False):
+        """Interactive per-dataset check by default - a curator picks one
+        dataset in the sync workspace and checks just that one. `check_all`
+        is a separate opt-in for summary use (e.g. the admin overview's
+        outdated-docs count), where checking every dataset at once is the
+        whole point rather than an accident of a missing dataset_id.
+        """
         session = self.db_session_factory()
         try:
-            if dataset_id is None:
+            if dataset_id is None and not check_all:
                 raise ValidationError(
                     "Dataset ID is required for interactive documentation sync"
                 )

--- a/src/dataio/api/services/chat_service.py
+++ b/src/dataio/api/services/chat_service.py
@@ -47,7 +47,7 @@ BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-3-5-sonnet-20
 # OpenRouter configuration
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-OPENROUTER_MODEL_ID = os.getenv("OPENROUTER_MODEL_ID", "anthropic/claude-3.5-sonnet")
+OPENROUTER_MODEL_ID = os.getenv("OPENROUTER_MODEL_ID", "anthropic/claude-sonnet-5")
 
 # System prompt for the chat assistant
 SYSTEM_PROMPT = """You are a helpful data assistant for the DataIO platform. Your role is to help users discover, understand, and work with datasets.

--- a/src/dataio/api/services/csv_profiler.py
+++ b/src/dataio/api/services/csv_profiler.py
@@ -1,0 +1,145 @@
+"""Deterministic, rule-based CSV profiling for the LLM drafter - dtypes,
+nulls, cardinality, sample values, and an explicit check for the
+source-citation columns the drafter is not allowed to invent. No LLM
+involved. See metadata-architecture memo, Stage 03.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pandas as pd
+from pydantic import BaseModel, Field
+
+# Source-citation concepts the drafter must find in the data rather than
+# invent - which document, which table within it, which page. Column
+# naming for these varies across datasets (a PDF-table-extraction might use
+# "sourceTableID"/"sourcePage"; an Excel-derived dataset may have no
+# per-row table/page concept at all, or name its citation column something
+# else entirely) - so detection is by keyword, against whatever column
+# names actually exist, not a fixed exact-name list. Keys are the fixed
+# metadata.yaml field names these concepts map to (see
+# metadata_field_reference.md); "source" itself isn't used as a keyword
+# since it's a common prefix across all three real conventions
+# (sourceDocument/sourceTableID/sourcePage) and wouldn't discriminate
+# between them.
+SOURCE_CONCEPT_KEYWORDS: dict[str, frozenset[str]] = {
+    "sourceDocument": frozenset({"document", "citation", "reference", "doc", "url", "pdf", "link", "publication", "report"}),
+    "sourceTableID": frozenset({"table"}),
+    "sourcePage": frozenset({"page"}),
+}
+
+_TOKEN_BOUNDARY_RE = re.compile(r"(?<!^)(?=[A-Z])|[_\.\-\s]+")
+
+
+def _tokenize_column_name(column_name: str) -> set[str]:
+    return {tok.lower() for tok in _TOKEN_BOUNDARY_RE.split(column_name) if tok}
+
+
+def detect_missing_source_concepts(column_names) -> list[str]:
+    """Which of SOURCE_CONCEPT_KEYWORDS has no matching column, by keyword
+    rather than exact name - so "SourceTable", "table_no", and
+    "sourceTableID" are all recognized as satisfying the same concept.
+    """
+    all_tokens: set[str] = set()
+    for column_name in column_names:
+        all_tokens |= _tokenize_column_name(str(column_name))
+    return [
+        concept
+        for concept, keywords in SOURCE_CONCEPT_KEYWORDS.items()
+        if not (all_tokens & keywords)
+    ]
+
+# Columns with at most this many distinct values get their COMPLETE value
+# list in the profile, not just a sample - these are exactly the columns
+# that become `enum` fields, and an enum's allowedValues has to cover every
+# value actually in the data or validation fails on whichever row has the
+# one value that didn't make a 10-item sample (e.g. a rare "breeding & work"
+# among many "breeding only" rows).
+ENUM_CANDIDATE_MAX_CARDINALITY = 200
+
+
+class ColumnProfile(BaseModel):
+    name: str
+    dtype: str
+    null_count: int
+    null_fraction: float
+    distinct_count: int
+    sample_values: list[str] = Field(default_factory=list)
+    # Populated only when distinct_count <= ENUM_CANDIDATE_MAX_CARDINALITY -
+    # the full, exhaustive set of values this column takes, in that case.
+    all_distinct_values: list[str] | None = None
+    min_value: str | None = None
+    max_value: str | None = None
+
+
+class CsvProfile(BaseModel):
+    path: str
+    row_count: int
+    columns: list[ColumnProfile]
+    missing_source_columns: list[str] = Field(default_factory=list)
+    sample_rows_csv: str = ""
+
+
+def profile_csv(path: str | Path, sample_rows: int = 20) -> CsvProfile:
+    df = pd.read_csv(path)
+
+    missing_source_columns = detect_missing_source_concepts(df.columns)
+
+    columns: list[ColumnProfile] = []
+    for column_name in df.columns:
+        series = df[column_name]
+        null_count = int(series.isna().sum())
+        row_count = len(series)
+        distinct_count = int(series.nunique(dropna=True))
+        distinct_values = series.dropna().unique()
+        sample_values = [str(v) for v in distinct_values[:10]]
+        all_distinct_values = (
+            sorted(str(v) for v in distinct_values)
+            if distinct_count <= ENUM_CANDIDATE_MAX_CARDINALITY
+            else None
+        )
+
+        min_value = None
+        max_value = None
+        numeric_series = pd.to_numeric(series, errors="coerce")
+        if numeric_series.notna().any():
+            min_value = str(numeric_series.min())
+            max_value = str(numeric_series.max())
+
+        columns.append(
+            ColumnProfile(
+                name=str(column_name),
+                dtype=str(series.dtype),
+                null_count=null_count,
+                null_fraction=(null_count / row_count) if row_count else 0.0,
+                distinct_count=distinct_count,
+                sample_values=sample_values,
+                all_distinct_values=all_distinct_values,
+                min_value=min_value,
+                max_value=max_value,
+            )
+        )
+
+    sample_rows_csv = df.head(sample_rows).to_csv(index=False)
+
+    return CsvProfile(
+        path=str(path),
+        row_count=len(df),
+        columns=columns,
+        missing_source_columns=missing_source_columns,
+        sample_rows_csv=sample_rows_csv,
+    )
+
+
+def read_full_csv_text(path: str | Path) -> str:
+    """The raw CSV text, embedded whole in the prompt for every table -
+    every table's actual content is always sent to the LLM, never
+    summarized away. Datasets whose combined full-CSV-text would exceed one
+    LLM call's context budget are split across multiple calls instead (see
+    draft_service._batch_tables), rather than any single table's content
+    being dropped down to a profile-only summary.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()

--- a/src/dataio/api/services/deterministic_draft_service.py
+++ b/src/dataio/api/services/deterministic_draft_service.py
@@ -20,15 +20,7 @@ from pydantic import BaseModel, Field
 
 from dataio.api.services import draft_service
 from dataio.api.services.csv_profiler import profile_csv
-from dataio.api.services.field_inference import (
-    apply_join_keys,
-    infer_data_dictionary,
-    infer_fixed_column_description,
-    infer_join_key_candidates,
-    lookup_canonical_enum_definitions,
-    match_canonical_values,
-)
-from dataio.api.services.region_gap_detector import detect_region_gaps_for_table
+from dataio.api.services.field_inference import infer_fixed_column_description, infer_table_structure
 
 
 class TagsInput(BaseModel):
@@ -125,35 +117,23 @@ def generate_deterministic_draft(
     missing_column_descriptions: list[str] = []
 
     for table_name, profile in csv_profiles.items():
-        data_dictionary, enum_definitions = infer_data_dictionary(profile)
-
-        # Merge this table's enum definitions into the dataset-wide block.
-        # _enum_ref_name only sees one column at a time, so two different
-        # tables with a same-named column (e.g. every table has its own
-        # "indicator"/"units"/"sourceTableID") get the same enumRef even
-        # though their observed values are entirely different - blindly
-        # `.update()`-ing would let the later table silently overwrite the
-        # earlier one's values, so every row of the earlier table then
-        # fails validation ("value does not satisfy type 'enum'") even
-        # though the value was real. Only rename on a genuine collision
-        # (same ref, different values) - identical enums shared across
-        # tables (e.g. a common locality: rural/urban/total) still merge
-        # under the one name, same as before.
-        for column_name, field in data_dictionary.items():
-            if field.get("type") != "enum":
-                continue
-            enum_ref = field["enumRef"]
-            definition = enum_definitions[enum_ref]
-            existing = dataset_enum_definitions.get(enum_ref)
-            if existing is not None and existing != definition:
-                suffix = 2
-                candidate = f"{enum_ref}{suffix}"
-                while candidate in dataset_enum_definitions and dataset_enum_definitions[candidate] != definition:
-                    suffix += 1
-                    candidate = f"{enum_ref}{suffix}"
-                enum_ref = candidate
-                field["enumRef"] = enum_ref
-            dataset_enum_definitions[enum_ref] = definition
+        # The curator confirms/adjusts join keys once, dataset-wide (see
+        # CuratorMetadataInput docstring) - a table only gets the subset of
+        # those columns it actually has (infer_table_structure handles the
+        # filtering). Type inference, enum-block collision-safe merging,
+        # canonical-registry cross-linking, and region-gap detection are
+        # all shared with the LLM drafter's pre-pass - see
+        # field_inference.infer_table_structure.
+        data_dictionary, table_join_keys, table_region_comments = infer_table_structure(
+            profile,
+            csv_paths_by_table[table_name],
+            dataset_enum_definitions,
+            dataset_canonical_enum_definitions,
+            join_key_columns_override=curator_input.joinKeyColumns,
+        )
+        for comment in table_region_comments:
+            if comment not in region_gap_comments:
+                region_gap_comments.append(comment)
 
         curator_column_descriptions = curator_input.columnDescriptions.get(table_name, {})
         for column_name, field in data_dictionary.items():
@@ -166,38 +146,6 @@ def generate_deterministic_draft(
                 field["description"] = curator_description
             else:
                 missing_column_descriptions.append(f"{table_name}.{column_name}")
-
-        column_names = [column.name for column in profile.columns]
-        dataset_canonical_enum_definitions.update(lookup_canonical_enum_definitions(column_names))
-
-        # Cross-link each enum column's observed values to the canonical
-        # block matched for its own name (if any) - e.g. "species" values
-        # get canonical/canonicalRollup keys pointing into
-        # canonicalEnumDefinitions.canonicalSpecies. Values with no
-        # normalized match are left untouched (see match_canonical_values).
-        for column_name, field in data_dictionary.items():
-            if field.get("type") != "enum":
-                continue
-            enum_values = dataset_enum_definitions.get(field["enumRef"], {}).get("values", {})
-            for canonical_definition in lookup_canonical_enum_definitions([column_name]).values():
-                for value, canonical_fields in match_canonical_values(
-                    list(enum_values.keys()), canonical_definition
-                ).items():
-                    enum_values[value].update(canonical_fields)
-
-        # The curator confirms/adjusts join keys once, dataset-wide (see
-        # CuratorMetadataInput docstring) - a table only gets the subset of
-        # those columns it actually has.
-        table_join_keys = curator_input.joinKeyColumns or infer_join_key_candidates(
-            profile, data_dictionary
-        )
-        table_join_keys = [name for name in table_join_keys if name in data_dictionary]
-        apply_join_keys(data_dictionary, table_join_keys)
-
-        table_csv_path = csv_paths_by_table[table_name]
-        for comment in detect_region_gaps_for_table(table_csv_path, data_dictionary):
-            if comment not in region_gap_comments:
-                region_gap_comments.append(comment)
 
         tables[table_name] = {
             "description": curator_input.tableDescriptions[table_name],

--- a/src/dataio/api/services/deterministic_draft_service.py
+++ b/src/dataio/api/services/deterministic_draft_service.py
@@ -1,0 +1,256 @@
+"""Orchestrates a fully deterministic (no-LLM) metadata-drafting run: the
+self-service replacement for draft_service.generate_draft agreed with
+Lijith (2026-07-24 Data-Platform Discussion) - profile the CSV(s), infer
+per-column types/enums and join-key candidates via field_inference.py,
+cross-check region history via region_gap_detector.py, combine with the
+curator's own directly-supplied fields (CuratorMetadataInput - replacing
+freeform digitization_log.yaml notes), and hand off to the SAME shared
+ID-resolution/validation/persistence tail draft_service.py already uses
+(_finalize_draft) - so a deterministic draft goes through the exact same
+pending/approved/rejected lifecycle as an LLM one, just with llm_model_id
+left unset.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from dataio.api.services import draft_service
+from dataio.api.services.csv_profiler import profile_csv
+from dataio.api.services.field_inference import (
+    apply_join_keys,
+    infer_data_dictionary,
+    infer_fixed_column_description,
+    infer_join_key_candidates,
+    lookup_canonical_enum_definitions,
+    match_canonical_values,
+)
+from dataio.api.services.region_gap_detector import detect_region_gaps_for_table
+
+
+class TagsInput(BaseModel):
+    concept: list[str] = Field(default_factory=list)
+    epiType: list[str] = Field(default_factory=list)
+
+
+class CuratorMetadataInput(BaseModel):
+    """The manifest fields no deterministic rule can derive from the CSV
+    alone - supplied directly by the curator through the intake form. This
+    replaces the freeform digitization_log.yaml notes Lijith flagged as
+    not upload-ready for a non-technical user: these are the exact fixed
+    top-level keys draft_prompt.MANIFEST_SCHEMA_HINT documents as
+    curator-owned, just captured as structured form fields instead of
+    prose an LLM has to interpret. `joinKeyColumns` is the curator's
+    confirmation of the candidates field_inference.infer_join_key_candidates
+    suggests - the one genuinely judgment-based field, so it's a human
+    confirming a deterministic suggestion, not free generation.
+    """
+
+    datasetDescription: str
+    source: list[str] = Field(default_factory=list)
+    references: list[str] = Field(default_factory=list)
+    tags: TagsInput = Field(default_factory=TagsInput)
+    spatialCoverage: str
+    spatialResolution: str
+    temporalCoverage: str
+    temporalResolution: str
+    updateFrequency: str
+    comments: list[str] = Field(default_factory=list)
+    joinKeyColumns: list[str] = Field(default_factory=list)
+    # One required entry per table (keyed by table name - the CSV filename
+    # stem, same convention csv_paths_by_table uses), since no rule can
+    # derive real table-level narrative from a CSV alone. Validated in
+    # generate_deterministic_draft, not here, since the set of table names
+    # isn't known until the CSVs are seen.
+    tableDescriptions: dict[str, str] = Field(default_factory=dict)
+    # One required entry per column not covered by
+    # field_inference.infer_fixed_column_description (keyed table_name ->
+    # column_name -> description) - a region-identifier or source/provenance
+    # column means the same thing in every dataset and is auto-filled
+    # instead; everything else is domain-specific and only a curator can
+    # meaningfully describe it. Also validated in generate_deterministic_draft.
+    columnDescriptions: dict[str, dict[str, str]] = Field(default_factory=dict)
+    # Only meaningful (and required) for a multi-CSV dataset - _finalize_draft
+    # always names a single-CSV dataset after that CSV's own filename
+    # regardless of this value (matches the established hand-authored
+    # convention). With more than one CSV there's no single file to name the
+    # dataset after, so the curator must supply one explicitly instead of a
+    # table getting picked arbitrarily.
+    datasetTitle: str = ""
+
+
+def generate_deterministic_draft(
+    *,
+    csv_paths: list[str],
+    category_id: str,
+    collection_id: str,
+    created_by: str,
+    data_owner_name: str,
+    curator_input: CuratorMetadataInput,
+    dataset_id: str | None = None,
+    digitization_log_path: str | None = None,
+    raw_dataset_id: str | None = None,
+    superseded_by_draft_id: str | None = None,
+) -> draft_service.DraftRecord:
+    if not csv_paths:
+        raise HTTPException(status_code=400, detail="At least one CSV file is required.")
+
+    # Same one-table-per-CSV convention as generate_draft.
+    csv_paths_by_table = {Path(p).stem: str(p) for p in csv_paths}
+
+    missing_descriptions = [
+        name for name in csv_paths_by_table
+        if not curator_input.tableDescriptions.get(name, "").strip()
+    ]
+    if missing_descriptions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing table description for: {', '.join(sorted(missing_descriptions))}.",
+        )
+    if len(csv_paths_by_table) > 1 and not curator_input.datasetTitle.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Dataset title is required when uploading more than one CSV.",
+        )
+
+    csv_profiles = {table_name: profile_csv(p) for table_name, p in csv_paths_by_table.items()}
+
+    tables: dict[str, dict] = {}
+    dataset_enum_definitions: dict[str, dict] = {}
+    dataset_canonical_enum_definitions: dict[str, dict] = {}
+    region_gap_comments: list[str] = []
+    missing_column_descriptions: list[str] = []
+
+    for table_name, profile in csv_profiles.items():
+        data_dictionary, enum_definitions = infer_data_dictionary(profile)
+
+        # Merge this table's enum definitions into the dataset-wide block.
+        # _enum_ref_name only sees one column at a time, so two different
+        # tables with a same-named column (e.g. every table has its own
+        # "indicator"/"units"/"sourceTableID") get the same enumRef even
+        # though their observed values are entirely different - blindly
+        # `.update()`-ing would let the later table silently overwrite the
+        # earlier one's values, so every row of the earlier table then
+        # fails validation ("value does not satisfy type 'enum'") even
+        # though the value was real. Only rename on a genuine collision
+        # (same ref, different values) - identical enums shared across
+        # tables (e.g. a common locality: rural/urban/total) still merge
+        # under the one name, same as before.
+        for column_name, field in data_dictionary.items():
+            if field.get("type") != "enum":
+                continue
+            enum_ref = field["enumRef"]
+            definition = enum_definitions[enum_ref]
+            existing = dataset_enum_definitions.get(enum_ref)
+            if existing is not None and existing != definition:
+                suffix = 2
+                candidate = f"{enum_ref}{suffix}"
+                while candidate in dataset_enum_definitions and dataset_enum_definitions[candidate] != definition:
+                    suffix += 1
+                    candidate = f"{enum_ref}{suffix}"
+                enum_ref = candidate
+                field["enumRef"] = enum_ref
+            dataset_enum_definitions[enum_ref] = definition
+
+        curator_column_descriptions = curator_input.columnDescriptions.get(table_name, {})
+        for column_name, field in data_dictionary.items():
+            fixed_description = infer_fixed_column_description(column_name)
+            if fixed_description is not None:
+                field["description"] = fixed_description
+                continue
+            curator_description = curator_column_descriptions.get(column_name, "").strip()
+            if curator_description:
+                field["description"] = curator_description
+            else:
+                missing_column_descriptions.append(f"{table_name}.{column_name}")
+
+        column_names = [column.name for column in profile.columns]
+        dataset_canonical_enum_definitions.update(lookup_canonical_enum_definitions(column_names))
+
+        # Cross-link each enum column's observed values to the canonical
+        # block matched for its own name (if any) - e.g. "species" values
+        # get canonical/canonicalRollup keys pointing into
+        # canonicalEnumDefinitions.canonicalSpecies. Values with no
+        # normalized match are left untouched (see match_canonical_values).
+        for column_name, field in data_dictionary.items():
+            if field.get("type") != "enum":
+                continue
+            enum_values = dataset_enum_definitions.get(field["enumRef"], {}).get("values", {})
+            for canonical_definition in lookup_canonical_enum_definitions([column_name]).values():
+                for value, canonical_fields in match_canonical_values(
+                    list(enum_values.keys()), canonical_definition
+                ).items():
+                    enum_values[value].update(canonical_fields)
+
+        # The curator confirms/adjusts join keys once, dataset-wide (see
+        # CuratorMetadataInput docstring) - a table only gets the subset of
+        # those columns it actually has.
+        table_join_keys = curator_input.joinKeyColumns or infer_join_key_candidates(
+            profile, data_dictionary
+        )
+        table_join_keys = [name for name in table_join_keys if name in data_dictionary]
+        apply_join_keys(data_dictionary, table_join_keys)
+
+        table_csv_path = csv_paths_by_table[table_name]
+        for comment in detect_region_gaps_for_table(table_csv_path, data_dictionary):
+            if comment not in region_gap_comments:
+                region_gap_comments.append(comment)
+
+        tables[table_name] = {
+            "description": curator_input.tableDescriptions[table_name],
+            "source": curator_input.source[0] if curator_input.source else "",
+            "joinKeys": table_join_keys,
+            "data_dictionary": data_dictionary,
+        }
+
+    if missing_column_descriptions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing description for: {', '.join(sorted(missing_column_descriptions))}.",
+        )
+
+    dataset_join_keys = curator_input.joinKeyColumns or sorted(
+        {column for table in tables.values() for column in table["joinKeys"]}
+    )
+
+    manifest_dict: dict = {
+        "datasetDescription": curator_input.datasetDescription,
+        "source": curator_input.source,
+        "tags": {"concept": curator_input.tags.concept, "epiType": curator_input.tags.epiType},
+        "spatialCoverage": curator_input.spatialCoverage,
+        "spatialResolution": curator_input.spatialResolution,
+        "temporalCoverage": curator_input.temporalCoverage,
+        "temporalResolution": curator_input.temporalResolution,
+        "updateFrequency": curator_input.updateFrequency,
+        "joinKeys": dataset_join_keys,
+        "comments": [*curator_input.comments, *region_gap_comments],
+        "references": curator_input.references,
+        "tables": tables,
+    }
+    if dataset_enum_definitions:
+        manifest_dict["enumDefinitions"] = dataset_enum_definitions
+    if dataset_canonical_enum_definitions:
+        manifest_dict["canonicalEnumDefinitions"] = dataset_canonical_enum_definitions
+    if curator_input.datasetTitle.strip():
+        # Ignored by _finalize_draft for a single-CSV dataset (it always uses
+        # that CSV's own filename instead) - only takes effect with 2+ CSVs.
+        manifest_dict["datasetTitle"] = curator_input.datasetTitle.strip()
+
+    return draft_service._finalize_draft(
+        manifest_dict=manifest_dict,
+        flags=[],
+        csv_paths_by_table=csv_paths_by_table,
+        csv_profiles=csv_profiles,
+        category_id=category_id,
+        collection_id=collection_id,
+        created_by=created_by,
+        data_owner_name=data_owner_name,
+        dataset_id=dataset_id,
+        raw_dataset_id=raw_dataset_id,
+        digitization_log_path=digitization_log_path,
+        superseded_by_draft_id=superseded_by_draft_id,
+        llm_model_id=None,
+    )

--- a/src/dataio/api/services/deterministic_draft_service.py
+++ b/src/dataio/api/services/deterministic_draft_service.py
@@ -13,8 +13,6 @@ left unset.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
@@ -90,8 +88,9 @@ def generate_deterministic_draft(
     if not csv_paths:
         raise HTTPException(status_code=400, detail="At least one CSV file is required.")
 
-    # Same one-table-per-CSV convention as generate_draft.
-    csv_paths_by_table = {Path(p).stem: str(p) for p in csv_paths}
+    # Same one-table-per-CSV convention as generate_draft, including its
+    # duplicate-filename-stem rejection.
+    csv_paths_by_table = draft_service.build_csv_paths_by_table(csv_paths)
 
     missing_descriptions = [
         name for name in csv_paths_by_table
@@ -160,9 +159,12 @@ def generate_deterministic_draft(
             detail=f"Missing description for: {', '.join(sorted(missing_column_descriptions))}.",
         )
 
-    dataset_join_keys = curator_input.joinKeyColumns or sorted(
-        {column for table in tables.values() for column in table["joinKeys"]}
-    )
+    # Always derived from each table's already-validated joinKeys (filtered
+    # against that table's real columns inside infer_table_structure) -
+    # never curator_input.joinKeyColumns directly, since an unfiltered
+    # curator override could reference a column that doesn't exist in any
+    # table (a typo, or a join-key list pasted from a different dataset).
+    dataset_join_keys = sorted({column for table in tables.values() for column in table["joinKeys"]})
 
     manifest_dict: dict = {
         "datasetDescription": curator_input.datasetDescription,

--- a/src/dataio/api/services/digitization_log.py
+++ b/src/dataio/api/services/digitization_log.py
@@ -1,0 +1,94 @@
+"""Digitization Log: a structured record a data engineer fills in alongside
+a raw dataset, capturing (a) source-document facts and (b) what they
+observed/normalized while digitizing it. The LLM drafter (draft_service.py)
+reads this so it doesn't re-flag something already explained on purpose -
+see metadata-architecture memo, Stage 02.
+
+Stored as <dataset_folder>/digitization_log.yaml, sibling to metadata.yaml
+and info.yml. A missing file is a valid, expected state: the drafter just
+flags everything instead of suppressing anything as already-explained.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class SourceDocument(BaseModel):
+    # Matches the real per-row metadata.yaml columns exactly (see
+    # metadata_field_reference.md): sourceDocument is the source PDF's
+    # URL/filename, sourceTableID the specific table within it, sourcePage
+    # the printed page number. There is no separate "statement" field in
+    # the real schema.
+    sourceDocument: str | None = None
+    sourceTableID: str | None = None
+    sourcePage: str | None = None
+
+
+class Observation(BaseModel):
+    id: str
+    description: str
+    affectedFields: list[str] = Field(default_factory=list)
+    # expected: not a data problem, don't re-flag it.
+    # needs_investigation: engineer noticed it but hasn't resolved it -
+    #   the drafter SHOULD still surface this one.
+    # wont_fix: known issue, accepted as-is.
+    resolution: str = "expected"
+
+
+class NormalizationStep(BaseModel):
+    id: str
+    description: str
+    field: str | None = None
+    changeType: str | None = None  # rename | dtype_cast | unit_conversion | value_recode | dedup | other
+
+
+class DigitizationLog(BaseModel):
+    schemaVersion: str = "1.0"
+    preparedBy: str | None = None
+    preparedAt: str | None = None
+    sourceDocuments: list[SourceDocument] = Field(default_factory=list)
+    observations: list[Observation] = Field(default_factory=list)
+    normalizationSteps: list[NormalizationStep] = Field(default_factory=list)
+    notes: str | None = None
+
+    def already_explained_summary(self) -> str:
+        """Renders the parts of this log the drafter must not re-derive or
+        re-flag, for direct inclusion in the LLM prompt.
+        """
+        lines: list[str] = []
+        for obs in self.observations:
+            if obs.resolution == "expected":
+                lines.append(f"- [{obs.id}] {obs.description}")
+        for step in self.normalizationSteps:
+            field_note = f" (field: {step.field})" if step.field else ""
+            lines.append(f"- [{step.id}] {step.description}{field_note}")
+        return "\n".join(lines)
+
+    def needs_investigation_summary(self) -> str:
+        """Observations the engineer flagged but did not resolve - the
+        drafter should still surface these, not suppress them.
+        """
+        lines = [
+            f"- [{obs.id}] {obs.description}"
+            for obs in self.observations
+            if obs.resolution == "needs_investigation"
+        ]
+        return "\n".join(lines)
+
+
+def load_digitization_log(path: str | Path | None) -> DigitizationLog | None:
+    """Returns None if `path` is None or the file doesn't exist - a missing
+    digitization log is expected and valid, not an error.
+    """
+    if not path:
+        return None
+    file_path = Path(path)
+    if not file_path.exists():
+        return None
+    with open(file_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    return DigitizationLog.model_validate(raw)

--- a/src/dataio/api/services/draft_prompt.py
+++ b/src/dataio/api/services/draft_prompt.py
@@ -4,6 +4,18 @@ decided rule from the metadata-architecture memo (LLM = Claude via
 OpenRouter, access_level not requested, dates best-effort not parsed,
 source facts never invented, gap explanations from general knowledge into
 comments, digitization-log-covered items never re-flagged).
+
+Column typing (type/nullable/format/allowedValues/enumRef/isJoinKey/
+joinKeyType), joinKeys, canonicalEnumDefinitions, and region-history
+comments are all decided deterministically before the LLM is ever called
+(see draft_service._infer_deterministic_base, field_inference.py) - the
+LLM only drafts genuinely natural-language content: descriptions, enum
+value/block definitions, dataset/table narrative fields, and comment
+categories no rule can derive (null-value semantics, units, redundant
+columns, completeness math, naming, source-to-year mapping, digitization
+log items). It never sees a table's raw CSV content, only the bounded
+per-column profile summary (stats + up to 200 distinct values + 20 sample
+rows) - so prompt size no longer scales with a table's row count.
 """
 
 from __future__ import annotations
@@ -13,19 +25,14 @@ import yaml
 from dataio.api.services.csv_profiler import CsvProfile
 from dataio.api.services.digitization_log import DigitizationLog
 
-# The exact, complete set of type keywords the validator recognizes -
-# anything else is a hard validation error, so the LLM must be given this
-# literal list rather than free-text examples it might paraphrase (e.g.
-# "integer" instead of "int").
-SUPPORTED_FIELD_TYPES = ("string", "boolean", "int", "float", "enum", "regionID", "regionName", "date", "dateTime")
-
-# A real, trimmed metadata.yaml (condensed from the actual CS0007DS0112 and
-# CS0026DS0111 datasets in data/) shown to the LLM verbatim as a structural
-# template - not to copy the content, but so the exact skeleton (key names,
-# nesting depth, list-vs-dict shape, the two-table convention) stays fixed
-# across every generation instead of drifting run to run. Enum value lists
-# and comments are trimmed to a representative few - real datasets are
-# denser than this, per the "Categories to check" list under `comments` below.
+# A real, trimmed metadata.yaml (condensed from the actual CS0007DS0112
+# dataset in data/) shown to the LLM verbatim as a structural template - not
+# to copy the content, but so the exact skeleton (key names, nesting depth,
+# list-vs-dict shape, the two-table convention) stays fixed across every
+# generation instead of drifting run to run. Trimmed to only the fields the
+# LLM is actually asked to produce (type/nullable/joinKeys/
+# canonicalEnumDefinitions and most data_dictionary columns are decided
+# deterministically - see module docstring - so they're absent here too).
 REFERENCE_METADATA_EXAMPLE = """
 datasetDescription: 'State-level livestock population counts from India''s 16th through
   20th Livestock Censuses (1997-2019), disaggregated by species, breed, sex, age group,
@@ -50,20 +57,6 @@ spatialResolution: state
 temporalCoverage: 1997, 2003, 2007, 2012, 2019
 temporalResolution: quinquennial
 updateFrequency: Quinquennial
-canonicalEnumDefinitions:
-  canonicalSpecies:
-    description: 'Cross-dataset canonical species vocabulary. Resolve species series
-      by this canonical key rather than dataset-local literal strings.'
-    values:
-      cattle:
-        grain: leaf
-      buffalo:
-        grain: leaf
-      bovine:
-        grain: group
-        components:
-        - cattle
-        - buffalo
 enumDefinitions:
   livestockSpecies:
     description: Canonical livestock species vocabulary for this dataset.
@@ -71,29 +64,13 @@ enumDefinitions:
       cattle:
         description: Domestic cattle. Includes both crossbred/exotic and indigenous
           breeds.
-        canonical: cattle
       buffalo:
         description: Domestic water buffalo.
-        canonical: buffalo
-  livestockSourceTableID:
-    description: Source table identifier within the livestock census publications.
-    values:
-      'Table 15R: Buffaloes Male Rural':
-        description: 'Source table: Table 15R: Buffaloes Male Rural'
-joinKeys:
-- state.lgd_code
-- state.ID
-- year
-- species
 comments:
-- Data covers cattle and buffalo only. Other species (sheep, goat, pig, etc.) are
-  not included.
 - Values are in actual animal counts (not thousands). Source PDFs report values in
   thousands; conversion to actual counts was applied during extraction.
-- Telangana is absent from 1997-2012 data (it was part of Andhra Pradesh until 2014).
-  It appears as a separate state from 2019 onwards.
-- state.lgd_code stores the numeric LGD code extracted from state.ID for both states
-  and union territories.
+- Count is null for state x year x species combinations where no census enumeration
+  occurred, not zero population - a blank means "not counted", not "counted as none".
 references:
 - https://dahd.gov.in/sites/default/files/2019-12/16thLivestockCensusBook.pdf
 tables:
@@ -103,63 +80,14 @@ tables:
 
       '
     source: 16th-20th Livestock Census PDFs (DAHD, Government of India)
-    joinKeys:
-    - state.lgd_code
-    - state.ID
-    - year
-    - species
     data_dictionary:
-      state.lgd_code:
-        type: int
-        description: 'Numeric LGD code extracted from state.ID for the state or union
-          territory.
-
-          '
-        nullable: false
-        isJoinKey: true
-        joinKeyType: compositeComponent
-      state.ID:
-        type: regionID
-        description: 'Prefixed LGD identifier for the state or union territory. Uses
-          ''state_'' for states and ''ut_'' for union territories.
-
-          '
-        nullable: false
-        isJoinKey: true
-        joinKeyType: compositeComponent
-      state.name:
-        type: regionName
-        description: State or union territory name standardised to LGD classification.
-        nullable: false
-      year:
-        type: date
-        format: '%Y'
-        description: Census reference year.
-        nullable: false
-        isJoinKey: true
-        joinKeyType: temporal
-      species:
-        type: enum
-        description: Livestock species. Either 'cattle' or 'buffalo'.
-        nullable: false
-        isJoinKey: true
-        joinKeyType: compositeComponent
-        enumRef: livestockSpecies
       count:
-        type: int
         description: 'Number of livestock of this species in the state for the given
           census year.
 
           '
-        nullable: true
-        additive: true
-        aggregation: sum
-      sourceTableID:
-        type: enum
-        description: Identifier of the specific table within the source PDF from which
-          this row was extracted.
-        nullable: true
-        enumRef: livestockSourceTableID
+      species:
+        description: Livestock species. Either 'cattle' or 'buffalo'.
   another-example-table-from-a-second-csv-in-this-dataset:
     description: 'Second table present ONLY when more than one CSV was uploaded for this
       dataset (e.g. a per-species yield table alongside a production table) - each
@@ -168,17 +96,12 @@ tables:
 
       '
     source: Same or a different source document, as appropriate for that table
-    joinKeys:
-    - state.lgd_code
-    - state.ID
-    - year
     data_dictionary:
-      state.lgd_code:
-        type: int
-        description: Numeric LGD code, same convention as the first table.
-        nullable: false
-        isJoinKey: true
-        joinKeyType: compositeComponent
+      indicator:
+        description: Example column that still needs a description - most columns
+          (region identifiers, source-provenance columns, year/date columns) already
+          have a fixed or deterministically-typed description and won't appear here
+          at all; only genuinely domain-specific columns do.
 """
 
 # This is the REAL, established metadata.yaml schema ("v2") used by every
@@ -187,7 +110,7 @@ tables:
 # dataDictionary). manifest_v2_conversion.py converts between the two for
 # validation - the exact same conversion the platform's own dataset-import
 # flow already uses.
-MANIFEST_SCHEMA_HINT = f"""
+MANIFEST_SCHEMA_HINT = """
 Produce a YAML document matching the real, established metadata.yaml schema (schema
 version "v2") used across every existing ARTPARK dataset. Do NOT produce datasetID,
 datasetSlug, metadataSpecVersion, category, collection, datasetOwner, or lastUpdated -
@@ -199,18 +122,26 @@ INCLUDE datasetTitle yourself: a short kebab-case, dataset-level name describing
 collection of tables (not any single table's name), since with multiple tables there's no
 one filename the system can safely default to.
 
+ALSO do NOT produce joinKeys or canonicalEnumDefinitions at any level, and do NOT include
+type, nullable, format, allowedValues, enumRef, isJoinKey, or joinKeyType inside any
+data_dictionary column entry - the system already decided all of that deterministically
+from the column statistics (shown below for context only) before calling you. Each table's
+"columns needing a `description`" section below tells you exactly which columns still need
+one and lists each one's already-decided type/enumRef as read-only context - do not restate
+it, only provide `description`. A column not listed there already has a description; do not
+add a data_dictionary entry for it at all.
+
 FIXED TOP-LEVEL KEYS - every one of the following MUST appear in your MANIFEST output
 (some may hold an empty list/dict when genuinely inapplicable, but the key itself must
 never be omitted): datasetDescription, source, tags (with both concept and epiType),
 spatialCoverage, spatialResolution, temporalCoverage, temporalResolution, updateFrequency,
-joinKeys, comments, references, tables. (datasetTitle, datasetSlug, datasetID,
-metadataSpecVersion, category, collection, datasetOwner, lastUpdated are also fixed keys,
-but the system fills those in for you - see above.) enumDefinitions and
-canonicalEnumDefinitions are conditionally-fixed: include enumDefinitions whenever any
-column is typed enum (nearly always), omit canonicalEnumDefinitions only when no column's
-values are worth rolling up cross-dataset. This is the exact same fixed-key set documented
-in metadata_field_reference.md - do not invent additional top-level keys and do not drop any
-of these.
+comments, references, tables. (datasetTitle, datasetSlug, datasetID, metadataSpecVersion,
+category, collection, datasetOwner, lastUpdated, joinKeys, and canonicalEnumDefinitions are
+also fixed keys, but the system fills those in for you - see above.) enumDefinitions is
+conditionally-fixed: include it whenever a table's "enum blocks needing definitions"
+section below is non-empty, omit it entirely otherwise. This is the same fixed-key set
+documented in metadata_field_reference.md - do not invent additional top-level keys and
+do not drop any of the keys listed above.
 
 datasetDescription: str (required) - narrative description of the dataset
 source: list of str (required) - one citation per source document/report
@@ -225,82 +156,24 @@ temporalCoverage: str (required) - free text describing the years/period covered
   separate start/end date fields.
 temporalResolution: str (required) - free text, e.g. "quinquennial", "annual", "monthly"
 updateFrequency: str (required) - e.g. "Quinquennial", "Annual", "One-time", "Adhoc"
-joinKeys: list of str (required) - dotted column names that together form this dataset's
-  composite key across its table(s). CRITICAL: whenever a `regionID`-typed column (e.g.
-  `state.ID`, `district.ID`) is part of the join key, its paired LGD code column (e.g.
-  `state.lgd_code`, `district.lgd_code`) MUST be included alongside it if that column exists
-  in the data - every real dataset in this system pairs the two together (e.g.
-  `["state.lgd_code", "state.ID", "year", ...]`), never the regionID alone.
-canonicalEnumDefinitions: optional - only include this block if this dataset has an enum
-  column whose values are worth rolling up to a broader, cross-dataset-joinable category
-  (e.g. a `species` column with "cattle" and "buffalo" both being kinds of "bovine"), so
-  that a curator can later join this dataset against others on the shared broader concept.
-  ESTABLISHED REGISTRY - livestock species/breed: every real dataset in this system with a
-  species or breed column uses this EXACT existing registry (ID "INL-98") - reuse it
-  verbatim, do not invent a new block or ID for this concept:
-    canonicalSpecies:
-      description: 'Cross-dataset canonical species vocabulary (INL-98). Resolve species
-        series by this canonical key rather than dataset-local literal strings.'
-      values:
-        cattle: {{grain: leaf}}
-        buffalo: {{grain: leaf}}
-        goat: {{grain: leaf}}
-        sheep: {{grain: leaf}}
-        pig: {{grain: leaf}}
-        poultry: {{grain: leaf}}
-        bovine: {{grain: group, components: [cattle, buffalo]}}
-        ovine_and_other_mammals: {{grain: group, components: [sheep, goat]}}
-        others: {{grain: residual}}
-    canonicalBreed:
-      description: 'Cross-dataset canonical breed vocabulary (INL-98). Census reports the
-        combined grain (crossbred_exotic); milk reports the split grain (exotic,
-        crossbred). For cross-dataset joins, match on canonicalRollup; for fine
-        within-dataset analysis, use canonical.'
-      values:
-        crossbred_exotic: {{grain: coarse, components: [exotic, crossbred]}}
-        exotic: {{grain: leaf, rollup: crossbred_exotic}}
-        crossbred: {{grain: leaf, rollup: crossbred_exotic}}
-        indigenous: {{grain: leaf}}
-        non_descript: {{grain: leaf}}
-        indigenous_non_descript: {{grain: coarse, components: [indigenous, non_descript]}}
-        none: {{grain: na}}
-        unspecified: {{grain: unknown}}
-  Include only the species/breed values this dataset actually needs (a dataset with no
-  breed column omits canonicalBreed entirely), but never rename the block, never rename a
-  value, and never invent a different ID for this same concept.
-  For any OTHER cross-dataset concept (not livestock species/breed): do NOT invent a registry ID
-  for the block (e.g. do not make up something like "INL-99") - name the block descriptively
-  instead and let the curator assign a real registry ID during review, since you have no way
-  of knowing whether one already exists for that other concept.
-    <canonicalBlockName>:
-      description: str
-      values:
-        <leafValue>:
-          grain: str - "leaf" for a value with no further breakdown
-        <groupValue>:
-          grain: str - "group" (or "coarse" for a rollup of leaf values) - a broader
-            category this dataset's own enum values roll up into
-          components: list of str - the sibling values (from this same block) that
-            make up this group
-        <valueThatRollsUp>:
-          grain: leaf
-          rollup: str - name of the group/coarse value (in this same block) that this
-            leaf value belongs to, when relevant
 enumDefinitions:
   <enumBlockName>:
     description: str
     values:
       <value>:
-        description: str
+        description: str - explain what this specific value actually MEANS, not just
+          restate the value literal (e.g. for value "crossbred/exotic": "Cattle/buffalo
+          resulting from cross-breeding indigenous with exotic breeds, or purebred exotic
+          stock" - not "crossbred/exotic animals").
 comments: list of str (required) - one distinct, plainly-stated FACT or documented decision
   about the DATA per list item (NOT a single paragraph - do not join everything into one
   string, and NOT meta-commentary about your own confidence as the drafter - see rule 2).
   Real metadata.yaml files are dense with these; match that density rather than settling for
-  one or two generic lines. Categories to check for on every dataset:
-    - Geographic entity history: which states/UTs/districts are absent in which years and
-      why (bifurcations, mergers, renamings), naming the specific years/dates involved.
+  one or two generic lines. Categories to check for on every dataset (region-history/
+  bifurcation gaps are already covered automatically - do not duplicate those here):
     - Null-value semantics: what a null/blank in a specific column actually means (not
-      reported vs. structurally not applicable vs. aggregated elsewhere).
+      reported vs. structurally not applicable vs. aggregated elsewhere) - reason only from
+      the null-count/sample-values context given per column, not from data you can't see.
     - Year/date column definition: whether "year" is the calendar year, the starting or
       ending year of an agricultural/financial year, a vaccination year vs. a report year, etc.
     - Source-to-year mapping: when different year ranges were extracted from different
@@ -320,24 +193,10 @@ tables: (required) - EXACTLY one entry per CSV table shown below, no more, no fe
   <tableName>:
     description: str
     source: str
-    joinKeys: list of str - same composite key columns, scoped to this table
     data_dictionary:
-      <columnName>:   # must exactly match the CSV's column header, verbatim
-        type: str - MUST be exactly one of: {", ".join(SUPPORTED_FIELD_TYPES)}. No other
-          value is accepted (e.g. "integer" is invalid - use "int").
+      <columnName>:   # ONLY for columns listed under this table's "columns needing a
+                       # `description`" section below - omit every other column entirely
         description: str
-        nullable: bool
-        isJoinKey: bool - true if this column is part of the composite key (omit otherwise)
-        joinKeyType: str - "compositeComponent" or "temporal", present only when isJoinKey is true
-        format: str - required for date/dateTime types, a strftime format (e.g. "%Y" for a
-          bare calendar year, "%Y-%m-%d" for a full date)
-        enumRef: str - name of an entry in enumDefinitions, for enum-type columns. STRONGLY
-          prefer this over allowedValues - a real enumDefinitions block with a per-value
-          description is far more useful to a curator than a bare list of values.
-        allowedValues: list - only if enumRef genuinely doesn't apply. Either way, every
-          distinct value this column actually takes in the data must be covered (see the
-          "all distinct values" list per column below where provided) - a value present in
-          the data but missing from the enum makes every row with that value fail validation.
 """
 
 RULES = """
@@ -352,9 +211,9 @@ Rules you must follow exactly:
    missing because it genuinely doesn't apply to how this dataset was digitized (e.g. no
    page-level reference for a single Excel workbook), say so in the flag rather than treating it
    as an error.
-2. If you notice a genuine gap in the data (a missing year, a missing region, etc.), explain it
-   using your own general/historical/administrative knowledge (e.g. a region absent from before
-   a certain year because of a state reorganization) as its own item in `comments`, stated
+2. If you notice a genuine gap in the data not already covered by an automatic region-history
+   comment (e.g. a missing year, a missing category due to a survey methodology change),
+   explain it using your own general/domain knowledge as its own item in `comments`, stated
    plainly as documented fact - never fold it into `datasetDescription`. `comments` documents
    the data, not the drafting process: never write things like "I am not fully confident" or
    "please verify this explanation" inside a comment. If you are not confident in an
@@ -366,37 +225,16 @@ Rules you must follow exactly:
    as its own item, prefixed with "[digitization log]".
 4. Anything listed under "Flagged by the digitization log as unresolved" should still be
    surfaced - the engineer noticed it but did not resolve it.
-5. Any column representing a calendar year or date MUST be typed `date` (or `dateTime`) with a
-   `format` containing `%Y` (e.g. `"%Y"` for a bare year column) - NOT `int` or `string`.
-6. Only use type `regionID` for a column whose values already look like `<lowercase-word>_<code>`
-   (e.g. `state_KA`). If the column is a plain code or name (a numeric LGD code, a state name,
-   etc.) that doesn't already follow that exact shape, use `string` or `int` instead. When a
-   `regionID` column is paired with a separate human-readable name column for the same place
-   (e.g. `state.ID` and `state.name`), type that name column `regionName`, not `string`.
-7. Whenever a `regionID` column (e.g. `state.ID`, `district.ID`) is part of the composite join
-   key, and a matching LGD code column for that same entity exists in the data (e.g.
-   `state.lgd_code`, `district.lgd_code`), that LGD code column MUST also be added to `joinKeys`
-   (both at the top level and in the table's own `joinKeys`) and marked `isJoinKey: true` with
-   `joinKeyType: compositeComponent` - never include the regionID alone. Every real dataset in
-   this system pairs them this way (e.g. `state.lgd_code` always appears next to `state.ID`).
-8. Prefer `enum` over `string`/`int` for ANY column with a small, closed set of distinct values
-   in the data - not just the columns that are obviously categorical. This absolutely includes
-   `sourceDocument` and `sourceTableID` when they only take a handful of distinct values (one
-   source PDF per year, a fixed set of table titles, etc.) - declare a real `enumDefinitions`
-   entry for them with a description per value, exactly like any other enum column, rather than
-   leaving them as plain `string`. Check the "all distinct values" list per column below: if it's
-   short, that column is very likely an enum candidate even if its name suggests free text.
-9. Do not raise a flag or comment just to ask the curator to "verify" something that isn't
+5. Do not raise a flag or comment just to ask the curator to "verify" something that isn't
    actually a problem:
    - Do not question whether a code column (an LGD code, a state ID, etc.) matches some
      external official registry - take the CSV's values at face value.
    - Do not flag inconsistent formatting in a free-text/string-typed column (e.g. sourceTableID)
-     as a caveat. Only raise a flag about a column's values if that column is typed `enum` and
-     some of its actual values aren't covered by the enum you declared.
+     as a caveat.
    - Do not flag a real-world name (a place name, an organization name, etc.) as "unusual" or
      "worth checking" just because it's long, verbose, or unfamiliar-looking. Long official
      names are common and are not evidence of a digitization error.
-10. YAML syntax safety - your output is parsed by a strict YAML parser, not read by a human:
+6. YAML syntax safety - your output is parsed by a strict YAML parser, not read by a human:
    double-quote (") any string value that contains a colon followed by a space (e.g. a table
    title like "Table 15R: Buffaloes Male Rural"), since an unquoted colon+space inside a plain
    scalar is parsed as a new mapping key and breaks the whole document. This applies to every
@@ -404,7 +242,7 @@ Rules you must follow exactly:
    value descriptions, flag reasons - anything that isn't a short bare keyword. When in doubt,
    double-quote the value. Never let a multi-line value span two physical lines without either
    quoting it onto one line or using a `|`/`>` block scalar.
-11. Output ONLY two YAML blocks, in this exact order, and nothing else:
+7. Output ONLY two YAML blocks, in this exact order, and nothing else:
    ---MANIFEST---
    <the manifest YAML>
    ---FLAGS---
@@ -435,6 +273,68 @@ def _format_csv_profile(table_name: str, profile: CsvProfile) -> str:
     lines.append("\nSample rows (CSV):")
     lines.append(profile.sample_rows_csv)
     return "\n".join(lines)
+
+
+def _format_deterministic_context(table_name: str, table_base: dict) -> str:
+    """Lists this table's columns that still need an LLM-authored
+    `description` - a column with a fixed structural description (region
+    identifiers, source-provenance columns - see
+    field_inference.infer_fixed_column_description) is already filled in
+    and omitted here entirely, so the LLM never wastes a turn re-describing
+    it. Each listed column's already-decided `type`/`enumRef` (from
+    field_inference.infer_column_type) is shown as read-only context to
+    help write an accurate description - the LLM is told not to restate it.
+    """
+    lines = [f"Table '{table_name}' - columns needing a `description` (type already decided, do not restate it):"]
+    any_needed = False
+    for column_name, field in table_base["data_dictionary"].items():
+        if field.get("description") is not None:
+            continue
+        any_needed = True
+        type_info = f"type={field.get('type')}"
+        if field.get("enumRef"):
+            type_info += f", enumRef={field['enumRef']}"
+        lines.append(f"  - {column_name}: {type_info}")
+    if not any_needed:
+        lines.append("  (none - every column in this table already has a fixed description)")
+    return "\n".join(lines)
+
+
+def _format_enum_context(table_base: dict, enum_definitions: dict) -> str:
+    """Lists the enum blocks this table's columns actually use (derived
+    from data_dictionary's own enumRef fields) that still need an
+    LLM-authored block description and per-value definitions - the
+    canonical/canonicalRollup linkage on each value (if any) is already
+    resolved deterministically (field_inference.match_canonical_values) and
+    not shown here, since the LLM isn't asked to reproduce it.
+    """
+    enum_refs = sorted(
+        {field["enumRef"] for field in table_base["data_dictionary"].values() if field.get("type") == "enum"}
+    )
+    if not enum_refs:
+        return ""
+    lines = [
+        "Enum blocks used by this table needing definitions - write a block-level "
+        "`description` and one `description` per value (explain what each value "
+        "actually MEANS, don't just restate the value literal):"
+    ]
+    for enum_ref in enum_refs:
+        values = list(enum_definitions.get(enum_ref, {}).get("values", {}).keys())
+        lines.append(f"  - {enum_ref}: values = {values}")
+    return "\n".join(lines)
+
+
+def estimate_table_context_size(table_name: str, profile: CsvProfile, table_base: dict | None = None) -> int:
+    """Character length of this table's prompt section - used by
+    draft_service._batch_tables to decide whether a dataset's tables fit in
+    one LLM call. Bounded by CsvProfile's own caps (up to 200 distinct
+    values, 20 sample rows) regardless of the table's real row count,
+    unlike the old full-CSV-text sizing this replaced.
+    """
+    size = len(_format_csv_profile(table_name, profile))
+    if table_base is not None:
+        size += len(_format_deterministic_context(table_name, table_base))
+    return size
 
 
 def _build_system_prompt() -> str:
@@ -474,11 +374,24 @@ def _digitization_log_sections(digitization_log: DigitizationLog | None) -> list
     return sections
 
 
+def _deterministic_context_sections(table_name: str, deterministic_base: dict | None) -> list[str]:
+    if deterministic_base is None:
+        return []
+    table_base = deterministic_base.get("tables", {}).get(table_name)
+    if table_base is None:
+        return []
+    sections = [_format_deterministic_context(table_name, table_base)]
+    enum_context = _format_enum_context(table_base, deterministic_base.get("enum_definitions", {}))
+    if enum_context:
+        sections.append(enum_context)
+    return sections
+
+
 def build_prompt(
     *,
     csv_profiles: dict[str, CsvProfile],
     digitization_log: DigitizationLog | None,
-    full_csv_texts: dict[str, str] | None = None,
+    deterministic_base: dict | None = None,
 ) -> tuple[str, str]:
     """Returns (system_prompt, user_prompt). `csv_profiles` maps table name
     (the uploaded CSV's filename stem) to its profile - one CSV upload per
@@ -486,19 +399,22 @@ def build_prompt(
     (see web_admin_service._parse_dataset_package's csv_by_stem). A single
     upload is just the len(csv_profiles) == 1 case, not a special path.
 
+    `deterministic_base` (see draft_service._infer_deterministic_base) is
+    the deterministically-inferred type/joinKeys/canonicalEnumDefinitions
+    skeleton - its per-table "columns needing a description"/"enum blocks
+    needing definitions" context replaces raw CSV row data in the prompt
+    entirely, so prompt size is bounded regardless of row count.
+
     Single LLM call, all tables at once - used when the dataset's combined
-    full-CSV-text fits one call's context budget. Datasets too large for
-    that use build_batch_prompt instead (see draft_service._batch_tables).
+    prompt-context size fits one call's context budget. Datasets too large
+    for that use build_batch_prompt instead (see draft_service._batch_tables).
     """
     system_prompt = _build_system_prompt()
 
-    full_csv_texts = full_csv_texts or {}
     sections = [f"This dataset has {len(csv_profiles)} table(s), one per uploaded CSV:"]
     for table_name, profile in csv_profiles.items():
         sections.append(_format_csv_profile(table_name, profile))
-        full_csv_text = full_csv_texts.get(table_name)
-        if full_csv_text is not None:
-            sections.append(f"Full CSV contents for table '{table_name}':\n" + full_csv_text)
+        sections.extend(_deterministic_context_sections(table_name, deterministic_base))
 
     sections.extend(_digitization_log_sections(digitization_log))
 
@@ -510,18 +426,17 @@ def build_batch_prompt(
     *,
     csv_profiles: dict[str, CsvProfile],
     digitization_log: DigitizationLog | None,
-    full_csv_texts: dict[str, str],
+    deterministic_base: dict,
     batch_table_names: list[str],
     include_dataset_level_fields: bool,
 ) -> tuple[str, str]:
     """Same task rules/schema as build_prompt (the system prompt never
-    changes per batch) - used when a dataset has too many/large CSVs for
+    changes per batch) - used when a dataset has too many/large tables for
     one call's context budget (see draft_service._batch_tables). Every
     table in the dataset is listed by name for cross-table context (so
-    joinKeys/comments/tags stay consistent across calls), but full CSV
-    content - and a `tables:` entry - is requested only for
-    batch_table_names; every table's real content still reaches the LLM,
-    just split across separate calls instead of ever being summarized away.
+    comments/tags stay consistent across calls), but a `tables:` entry -
+    and per-table description/enum-definition context - is requested only
+    for batch_table_names.
 
     Dataset-wide narrative fields (datasetDescription, source, etc.) are
     requested only when include_dataset_level_fields is True - normally
@@ -537,34 +452,31 @@ def build_batch_prompt(
         f"This dataset has {len(all_table_names)} table(s) total: {', '.join(all_table_names)}.",
         f"This call covers {len(batch_table_names)} of them: {', '.join(batch_table_names)}. "
         "Produce a `tables:` entry ONLY for these - the rest are listed below for "
-        "cross-table context (so your joinKeys/comments/tags stay consistent with the "
-        "rest of the dataset) but are drafted in separate calls; do not invent a "
+        "cross-table context (so your comments/tags stay consistent with the rest "
+        "of the dataset) but are drafted in separate calls; do not invent a "
         "`tables:` entry for any table not in this list.",
     ]
     if include_dataset_level_fields:
         sections.append(
             "This is the FIRST call for this dataset - also produce the dataset-wide "
             "fields (datasetDescription, source, spatialCoverage, spatialResolution, "
-            "temporalCoverage, temporalResolution, updateFrequency, references, "
-            "canonicalEnumDefinitions) as normal, based on the tables shown to you here."
+            "temporalCoverage, temporalResolution, updateFrequency, references) as "
+            "normal, based on the tables shown to you here."
         )
     else:
         sections.append(
             "This is NOT the first call for this dataset - a separate call already "
             "produced datasetDescription, source, spatialCoverage, spatialResolution, "
             "temporalCoverage, temporalResolution, updateFrequency, and references. Omit "
-            "those keys entirely from your MANIFEST output. You MAY still include "
-            "joinKeys, tags, comments, and enumDefinitions/canonicalEnumDefinitions "
-            "scoped to the tables shown to you here - these will be merged with the "
-            "other calls' contributions afterward."
+            "those keys entirely from your MANIFEST output. You MAY still include tags "
+            "and comments scoped to the tables shown to you here - these will be merged "
+            "with the other calls' contributions afterward."
         )
 
     for table_name, profile in csv_profiles.items():
         if table_name in batch_set:
             sections.append(_format_csv_profile(table_name, profile))
-            full_csv_text = full_csv_texts.get(table_name)
-            if full_csv_text is not None:
-                sections.append(f"Full CSV contents for table '{table_name}':\n" + full_csv_text)
+            sections.extend(_deterministic_context_sections(table_name, deterministic_base))
         else:
             column_names = [col.name for col in profile.columns]
             sections.append(

--- a/src/dataio/api/services/draft_prompt.py
+++ b/src/dataio/api/services/draft_prompt.py
@@ -1,0 +1,606 @@
+"""Builds the system/user prompt for the LLM metadata drafter, and parses
+its response back into a manifest dict + a flags list. Encodes every
+decided rule from the metadata-architecture memo (LLM = Claude via
+OpenRouter, access_level not requested, dates best-effort not parsed,
+source facts never invented, gap explanations from general knowledge into
+comments, digitization-log-covered items never re-flagged).
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from dataio.api.services.csv_profiler import CsvProfile
+from dataio.api.services.digitization_log import DigitizationLog
+
+# The exact, complete set of type keywords the validator recognizes -
+# anything else is a hard validation error, so the LLM must be given this
+# literal list rather than free-text examples it might paraphrase (e.g.
+# "integer" instead of "int").
+SUPPORTED_FIELD_TYPES = ("string", "boolean", "int", "float", "enum", "regionID", "regionName", "date", "dateTime")
+
+# A real, trimmed metadata.yaml (condensed from the actual CS0007DS0112 and
+# CS0026DS0111 datasets in data/) shown to the LLM verbatim as a structural
+# template - not to copy the content, but so the exact skeleton (key names,
+# nesting depth, list-vs-dict shape, the two-table convention) stays fixed
+# across every generation instead of drifting run to run. Enum value lists
+# and comments are trimmed to a representative few - real datasets are
+# denser than this, per the "Categories to check" list under `comments` below.
+REFERENCE_METADATA_EXAMPLE = """
+datasetDescription: 'State-level livestock population counts from India''s 16th through
+  20th Livestock Censuses (1997-2019), disaggregated by species, breed, sex, age group,
+  utility, and locality. Each row represents the count of animals for a specific
+  state x year x species x breed x sex x age.group x utility x locality combination.
+
+  '
+source:
+- 16th Livestock Census 1997 - Department of Animal Husbandry, Dairying & Fisheries,
+  Government of India
+- 20th Livestock Census 2019 - Department of Animal Husbandry & Dairying, Government
+  of India
+tags:
+  concept:
+  - livestock
+  - cattle
+  - buffalo
+  epiType:
+  - population
+spatialCoverage: India
+spatialResolution: state
+temporalCoverage: 1997, 2003, 2007, 2012, 2019
+temporalResolution: quinquennial
+updateFrequency: Quinquennial
+canonicalEnumDefinitions:
+  canonicalSpecies:
+    description: 'Cross-dataset canonical species vocabulary. Resolve species series
+      by this canonical key rather than dataset-local literal strings.'
+    values:
+      cattle:
+        grain: leaf
+      buffalo:
+        grain: leaf
+      bovine:
+        grain: group
+        components:
+        - cattle
+        - buffalo
+enumDefinitions:
+  livestockSpecies:
+    description: Canonical livestock species vocabulary for this dataset.
+    values:
+      cattle:
+        description: Domestic cattle. Includes both crossbred/exotic and indigenous
+          breeds.
+        canonical: cattle
+      buffalo:
+        description: Domestic water buffalo.
+        canonical: buffalo
+  livestockSourceTableID:
+    description: Source table identifier within the livestock census publications.
+    values:
+      'Table 15R: Buffaloes Male Rural':
+        description: 'Source table: Table 15R: Buffaloes Male Rural'
+joinKeys:
+- state.lgd_code
+- state.ID
+- year
+- species
+comments:
+- Data covers cattle and buffalo only. Other species (sheep, goat, pig, etc.) are
+  not included.
+- Values are in actual animal counts (not thousands). Source PDFs report values in
+  thousands; conversion to actual counts was applied during extraction.
+- Telangana is absent from 1997-2012 data (it was part of Andhra Pradesh until 2014).
+  It appears as a separate state from 2019 onwards.
+- state.lgd_code stores the numeric LGD code extracted from state.ID for both states
+  and union territories.
+references:
+- https://dahd.gov.in/sites/default/files/2019-12/16thLivestockCensusBook.pdf
+tables:
+  consolidated-livestock-census:
+    description: 'State-level livestock population counts disaggregated by species,
+      breed, sex, age group, utility, and locality across five census years (1997-2019).
+
+      '
+    source: 16th-20th Livestock Census PDFs (DAHD, Government of India)
+    joinKeys:
+    - state.lgd_code
+    - state.ID
+    - year
+    - species
+    data_dictionary:
+      state.lgd_code:
+        type: int
+        description: 'Numeric LGD code extracted from state.ID for the state or union
+          territory.
+
+          '
+        nullable: false
+        isJoinKey: true
+        joinKeyType: compositeComponent
+      state.ID:
+        type: regionID
+        description: 'Prefixed LGD identifier for the state or union territory. Uses
+          ''state_'' for states and ''ut_'' for union territories.
+
+          '
+        nullable: false
+        isJoinKey: true
+        joinKeyType: compositeComponent
+      state.name:
+        type: regionName
+        description: State or union territory name standardised to LGD classification.
+        nullable: false
+      year:
+        type: date
+        format: '%Y'
+        description: Census reference year.
+        nullable: false
+        isJoinKey: true
+        joinKeyType: temporal
+      species:
+        type: enum
+        description: Livestock species. Either 'cattle' or 'buffalo'.
+        nullable: false
+        isJoinKey: true
+        joinKeyType: compositeComponent
+        enumRef: livestockSpecies
+      count:
+        type: int
+        description: 'Number of livestock of this species in the state for the given
+          census year.
+
+          '
+        nullable: true
+        additive: true
+        aggregation: sum
+      sourceTableID:
+        type: enum
+        description: Identifier of the specific table within the source PDF from which
+          this row was extracted.
+        nullable: true
+        enumRef: livestockSourceTableID
+  another-example-table-from-a-second-csv-in-this-dataset:
+    description: 'Second table present ONLY when more than one CSV was uploaded for this
+      dataset (e.g. a per-species yield table alongside a production table) - each
+      uploaded CSV becomes its own entry here, named after that CSV''s own filename
+      stem verbatim, not this placeholder name.
+
+      '
+    source: Same or a different source document, as appropriate for that table
+    joinKeys:
+    - state.lgd_code
+    - state.ID
+    - year
+    data_dictionary:
+      state.lgd_code:
+        type: int
+        description: Numeric LGD code, same convention as the first table.
+        nullable: false
+        isJoinKey: true
+        joinKeyType: compositeComponent
+"""
+
+# This is the REAL, established metadata.yaml schema ("v2") used by every
+# existing ARTPARK dataset - not the newer dataio.validate.contracts.models
+# Pydantic contract, which uses different key names (datasetTables/
+# dataDictionary). manifest_v2_conversion.py converts between the two for
+# validation - the exact same conversion the platform's own dataset-import
+# flow already uses.
+MANIFEST_SCHEMA_HINT = f"""
+Produce a YAML document matching the real, established metadata.yaml schema (schema
+version "v2") used across every existing ARTPARK dataset. Do NOT produce datasetID,
+datasetSlug, metadataSpecVersion, category, collection, datasetOwner, or lastUpdated -
+the system fills those in automatically after you respond, from information (the curator's
+own selections) you don't have access to. datasetTitle: if only one CSV table is shown
+below, also omit datasetTitle - the system uses that CSV's own filename verbatim, matching
+the established single-table convention. If MORE THAN ONE CSV table is shown below,
+INCLUDE datasetTitle yourself: a short kebab-case, dataset-level name describing the whole
+collection of tables (not any single table's name), since with multiple tables there's no
+one filename the system can safely default to.
+
+FIXED TOP-LEVEL KEYS - every one of the following MUST appear in your MANIFEST output
+(some may hold an empty list/dict when genuinely inapplicable, but the key itself must
+never be omitted): datasetDescription, source, tags (with both concept and epiType),
+spatialCoverage, spatialResolution, temporalCoverage, temporalResolution, updateFrequency,
+joinKeys, comments, references, tables. (datasetTitle, datasetSlug, datasetID,
+metadataSpecVersion, category, collection, datasetOwner, lastUpdated are also fixed keys,
+but the system fills those in for you - see above.) enumDefinitions and
+canonicalEnumDefinitions are conditionally-fixed: include enumDefinitions whenever any
+column is typed enum (nearly always), omit canonicalEnumDefinitions only when no column's
+values are worth rolling up cross-dataset. This is the exact same fixed-key set documented
+in metadata_field_reference.md - do not invent additional top-level keys and do not drop any
+of these.
+
+datasetDescription: str (required) - narrative description of the dataset
+source: list of str (required) - one citation per source document/report
+tags: (required)
+  concept: list of str - domain concepts this dataset relates to
+  epiType: list of str - e.g. "population", "incidence", "mortality"
+spatialCoverage: str (required) - e.g. "India"
+spatialResolution: str (required) - e.g. "state", "district"
+temporalCoverage: str (required) - free text describing the years/period covered, in
+  whatever shape is natural for this data (e.g. "1997, 2003, 2007, 2012, 2019" for
+  irregular census years, or "1950-2024" for a continuous range) - NOT split into
+  separate start/end date fields.
+temporalResolution: str (required) - free text, e.g. "quinquennial", "annual", "monthly"
+updateFrequency: str (required) - e.g. "Quinquennial", "Annual", "One-time", "Adhoc"
+joinKeys: list of str (required) - dotted column names that together form this dataset's
+  composite key across its table(s). CRITICAL: whenever a `regionID`-typed column (e.g.
+  `state.ID`, `district.ID`) is part of the join key, its paired LGD code column (e.g.
+  `state.lgd_code`, `district.lgd_code`) MUST be included alongside it if that column exists
+  in the data - every real dataset in this system pairs the two together (e.g.
+  `["state.lgd_code", "state.ID", "year", ...]`), never the regionID alone.
+canonicalEnumDefinitions: optional - only include this block if this dataset has an enum
+  column whose values are worth rolling up to a broader, cross-dataset-joinable category
+  (e.g. a `species` column with "cattle" and "buffalo" both being kinds of "bovine"), so
+  that a curator can later join this dataset against others on the shared broader concept.
+  ESTABLISHED REGISTRY - livestock species/breed: every real dataset in this system with a
+  species or breed column uses this EXACT existing registry (ID "INL-98") - reuse it
+  verbatim, do not invent a new block or ID for this concept:
+    canonicalSpecies:
+      description: 'Cross-dataset canonical species vocabulary (INL-98). Resolve species
+        series by this canonical key rather than dataset-local literal strings.'
+      values:
+        cattle: {{grain: leaf}}
+        buffalo: {{grain: leaf}}
+        goat: {{grain: leaf}}
+        sheep: {{grain: leaf}}
+        pig: {{grain: leaf}}
+        poultry: {{grain: leaf}}
+        bovine: {{grain: group, components: [cattle, buffalo]}}
+        ovine_and_other_mammals: {{grain: group, components: [sheep, goat]}}
+        others: {{grain: residual}}
+    canonicalBreed:
+      description: 'Cross-dataset canonical breed vocabulary (INL-98). Census reports the
+        combined grain (crossbred_exotic); milk reports the split grain (exotic,
+        crossbred). For cross-dataset joins, match on canonicalRollup; for fine
+        within-dataset analysis, use canonical.'
+      values:
+        crossbred_exotic: {{grain: coarse, components: [exotic, crossbred]}}
+        exotic: {{grain: leaf, rollup: crossbred_exotic}}
+        crossbred: {{grain: leaf, rollup: crossbred_exotic}}
+        indigenous: {{grain: leaf}}
+        non_descript: {{grain: leaf}}
+        indigenous_non_descript: {{grain: coarse, components: [indigenous, non_descript]}}
+        none: {{grain: na}}
+        unspecified: {{grain: unknown}}
+  Include only the species/breed values this dataset actually needs (a dataset with no
+  breed column omits canonicalBreed entirely), but never rename the block, never rename a
+  value, and never invent a different ID for this same concept.
+  For any OTHER cross-dataset concept (not livestock species/breed): do NOT invent a registry ID
+  for the block (e.g. do not make up something like "INL-99") - name the block descriptively
+  instead and let the curator assign a real registry ID during review, since you have no way
+  of knowing whether one already exists for that other concept.
+    <canonicalBlockName>:
+      description: str
+      values:
+        <leafValue>:
+          grain: str - "leaf" for a value with no further breakdown
+        <groupValue>:
+          grain: str - "group" (or "coarse" for a rollup of leaf values) - a broader
+            category this dataset's own enum values roll up into
+          components: list of str - the sibling values (from this same block) that
+            make up this group
+        <valueThatRollsUp>:
+          grain: leaf
+          rollup: str - name of the group/coarse value (in this same block) that this
+            leaf value belongs to, when relevant
+enumDefinitions:
+  <enumBlockName>:
+    description: str
+    values:
+      <value>:
+        description: str
+comments: list of str (required) - one distinct, plainly-stated FACT or documented decision
+  about the DATA per list item (NOT a single paragraph - do not join everything into one
+  string, and NOT meta-commentary about your own confidence as the drafter - see rule 2).
+  Real metadata.yaml files are dense with these; match that density rather than settling for
+  one or two generic lines. Categories to check for on every dataset:
+    - Geographic entity history: which states/UTs/districts are absent in which years and
+      why (bifurcations, mergers, renamings), naming the specific years/dates involved.
+    - Null-value semantics: what a null/blank in a specific column actually means (not
+      reported vs. structurally not applicable vs. aggregated elsewhere).
+    - Year/date column definition: whether "year" is the calendar year, the starting or
+      ending year of an agricultural/financial year, a vaccination year vs. a report year, etc.
+    - Source-to-year mapping: when different year ranges were extracted from different
+      source editions/reports/tables, document exactly which years came from which source.
+    - Units and conventions: counts vs. thousands, absolute vs. percentage, any conversion
+      applied during extraction.
+    - Redundant/derived columns: note when one column's value is fully determined by another
+      (e.g. species derivable from breed) and is kept only for filtering convenience.
+    - Completeness: row-count math (e.g. states x categories = total rows) and whether the
+      dataset is fully populated or has known gaps.
+    - Naming/standardization: which naming convention was applied and why (e.g. LGD standard,
+      post-2014 official renamings).
+references: list of str (required) - source document URLs
+tables: (required) - EXACTLY one entry per CSV table shown below, no more, no fewer. Use
+  the table name given for each CSV (its filename's stem) verbatim as the key - do not
+  rename, reformat, or invent a different table name.
+  <tableName>:
+    description: str
+    source: str
+    joinKeys: list of str - same composite key columns, scoped to this table
+    data_dictionary:
+      <columnName>:   # must exactly match the CSV's column header, verbatim
+        type: str - MUST be exactly one of: {", ".join(SUPPORTED_FIELD_TYPES)}. No other
+          value is accepted (e.g. "integer" is invalid - use "int").
+        description: str
+        nullable: bool
+        isJoinKey: bool - true if this column is part of the composite key (omit otherwise)
+        joinKeyType: str - "compositeComponent" or "temporal", present only when isJoinKey is true
+        format: str - required for date/dateTime types, a strftime format (e.g. "%Y" for a
+          bare calendar year, "%Y-%m-%d" for a full date)
+        enumRef: str - name of an entry in enumDefinitions, for enum-type columns. STRONGLY
+          prefer this over allowedValues - a real enumDefinitions block with a per-value
+          description is far more useful to a curator than a bare list of values.
+        allowedValues: list - only if enumRef genuinely doesn't apply. Either way, every
+          distinct value this column actually takes in the data must be covered (see the
+          "all distinct values" list per column below where provided) - a value present in
+          the data but missing from the enum makes every row with that value fail validation.
+"""
+
+RULES = """
+Rules you must follow exactly:
+1. Source-citation facts - which document this came from, which table within it, which page -
+   are expected to already be in the CSV, under whatever column names this dataset actually
+   uses (naming varies: a PDF-table extraction might have "sourceTableID"/"sourcePage"; an
+   Excel-derived dataset may have no per-row table/page concept at all). Do NOT invent a value
+   for a concept the CSV doesn't actually contain a column for (see "Missing source concepts"
+   below, detected by keyword against the real column names, not an exact-name check) - add an
+   entry to the `flags` list instead of leaving it blank or making something up. If a concept is
+   missing because it genuinely doesn't apply to how this dataset was digitized (e.g. no
+   page-level reference for a single Excel workbook), say so in the flag rather than treating it
+   as an error.
+2. If you notice a genuine gap in the data (a missing year, a missing region, etc.), explain it
+   using your own general/historical/administrative knowledge (e.g. a region absent from before
+   a certain year because of a state reorganization) as its own item in `comments`, stated
+   plainly as documented fact - never fold it into `datasetDescription`. `comments` documents
+   the data, not the drafting process: never write things like "I am not fully confident" or
+   "please verify this explanation" inside a comment. If you are not confident in an
+   explanation, leave the comment out and raise a `flags` entry for the curator instead - do
+   not hedge inside `comments`.
+3. Anything listed below under "Already explained by the digitization log" is a normalization
+   step or observation the data engineer already investigated and resolved on purpose. Do not re-flag
+   it as a fresh caveat or gap - if relevant, fold the engineer's own explanation into `comments`
+   as its own item, prefixed with "[digitization log]".
+4. Anything listed under "Flagged by the digitization log as unresolved" should still be
+   surfaced - the engineer noticed it but did not resolve it.
+5. Any column representing a calendar year or date MUST be typed `date` (or `dateTime`) with a
+   `format` containing `%Y` (e.g. `"%Y"` for a bare year column) - NOT `int` or `string`.
+6. Only use type `regionID` for a column whose values already look like `<lowercase-word>_<code>`
+   (e.g. `state_KA`). If the column is a plain code or name (a numeric LGD code, a state name,
+   etc.) that doesn't already follow that exact shape, use `string` or `int` instead. When a
+   `regionID` column is paired with a separate human-readable name column for the same place
+   (e.g. `state.ID` and `state.name`), type that name column `regionName`, not `string`.
+7. Whenever a `regionID` column (e.g. `state.ID`, `district.ID`) is part of the composite join
+   key, and a matching LGD code column for that same entity exists in the data (e.g.
+   `state.lgd_code`, `district.lgd_code`), that LGD code column MUST also be added to `joinKeys`
+   (both at the top level and in the table's own `joinKeys`) and marked `isJoinKey: true` with
+   `joinKeyType: compositeComponent` - never include the regionID alone. Every real dataset in
+   this system pairs them this way (e.g. `state.lgd_code` always appears next to `state.ID`).
+8. Prefer `enum` over `string`/`int` for ANY column with a small, closed set of distinct values
+   in the data - not just the columns that are obviously categorical. This absolutely includes
+   `sourceDocument` and `sourceTableID` when they only take a handful of distinct values (one
+   source PDF per year, a fixed set of table titles, etc.) - declare a real `enumDefinitions`
+   entry for them with a description per value, exactly like any other enum column, rather than
+   leaving them as plain `string`. Check the "all distinct values" list per column below: if it's
+   short, that column is very likely an enum candidate even if its name suggests free text.
+9. Do not raise a flag or comment just to ask the curator to "verify" something that isn't
+   actually a problem:
+   - Do not question whether a code column (an LGD code, a state ID, etc.) matches some
+     external official registry - take the CSV's values at face value.
+   - Do not flag inconsistent formatting in a free-text/string-typed column (e.g. sourceTableID)
+     as a caveat. Only raise a flag about a column's values if that column is typed `enum` and
+     some of its actual values aren't covered by the enum you declared.
+   - Do not flag a real-world name (a place name, an organization name, etc.) as "unusual" or
+     "worth checking" just because it's long, verbose, or unfamiliar-looking. Long official
+     names are common and are not evidence of a digitization error.
+10. YAML syntax safety - your output is parsed by a strict YAML parser, not read by a human:
+   double-quote (") any string value that contains a colon followed by a space (e.g. a table
+   title like "Table 15R: Buffaloes Male Rural"), since an unquoted colon+space inside a plain
+   scalar is parsed as a new mapping key and breaks the whole document. This applies to every
+   free-text value: `description`, `comments` list items, `source`/`references` entries, enum
+   value descriptions, flag reasons - anything that isn't a short bare keyword. When in doubt,
+   double-quote the value. Never let a multi-line value span two physical lines without either
+   quoting it onto one line or using a `|`/`>` block scalar.
+11. Output ONLY two YAML blocks, in this exact order, and nothing else:
+   ---MANIFEST---
+   <the manifest YAML>
+   ---FLAGS---
+   flags:
+     - field: <dotted path or column name>
+       reason: <why this needs curator attention>
+"""
+
+
+def _format_csv_profile(table_name: str, profile: CsvProfile) -> str:
+    lines = [f"## Table: {table_name}  (source file: {profile.path})", f"Row count: {profile.row_count}", "Columns:"]
+    for col in profile.columns:
+        lines.append(
+            f"  - {col.name}: dtype={col.dtype}, nulls={col.null_count} "
+            f"({col.null_fraction:.1%}), distinct={col.distinct_count}, "
+            f"sample={col.sample_values[:5]}"
+            + (f", range=[{col.min_value}, {col.max_value}]" if col.min_value is not None else "")
+        )
+        if col.all_distinct_values is not None:
+            lines.append(f"      all distinct values ({len(col.all_distinct_values)}): {col.all_distinct_values}")
+    if profile.missing_source_columns:
+        lines.append(
+            f"\nMissing source concepts (no column keyword-matched, checked across all "
+            f"column names above): {profile.missing_source_columns}"
+        )
+    else:
+        lines.append("\nMissing source concepts: none")
+    lines.append("\nSample rows (CSV):")
+    lines.append(profile.sample_rows_csv)
+    return "\n".join(lines)
+
+
+def _build_system_prompt() -> str:
+    return (
+        "You are drafting a metadata.yaml manifest for a new ARTPARK dataset, "
+        "for a human curator to review and approve before anything is uploaded. "
+        "You are not the final decision-maker - flag anything you're unsure about "
+        "rather than guessing silently.\n\n"
+        + MANIFEST_SCHEMA_HINT
+        + RULES
+        + "\n\nReference example - a real (trimmed) metadata.yaml showing the exact "
+        "structural skeleton to follow (key names, nesting, list-vs-dict shape). Do not "
+        "reuse its subject matter/content, only its shape - the second table entry shown "
+        "is a placeholder illustrating the two-CSVs-in-one-dataset case; include a second "
+        "table only if more than one CSV was actually provided to you below:\n"
+        + REFERENCE_METADATA_EXAMPLE
+    )
+
+
+def _digitization_log_sections(digitization_log: DigitizationLog | None) -> list[str]:
+    already_explained = digitization_log.already_explained_summary() if digitization_log else ""
+    needs_investigation = digitization_log.needs_investigation_summary() if digitization_log else ""
+    source_documents = (
+        yaml.safe_dump([d.model_dump(exclude_none=True) for d in digitization_log.sourceDocuments])
+        if digitization_log and digitization_log.sourceDocuments
+        else ""
+    )
+
+    sections = [
+        "Already explained by the digitization log (do not re-flag these):\n"
+        + (already_explained or "(none - no digitization log was provided, or nothing was marked expected)"),
+        "Flagged by the digitization log as unresolved (still surface these):\n"
+        + (needs_investigation or "(none)"),
+    ]
+    if source_documents:
+        sections.append("Source documents recorded in the digitization log:\n" + source_documents)
+    return sections
+
+
+def build_prompt(
+    *,
+    csv_profiles: dict[str, CsvProfile],
+    digitization_log: DigitizationLog | None,
+    full_csv_texts: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    """Returns (system_prompt, user_prompt). `csv_profiles` maps table name
+    (the uploaded CSV's filename stem) to its profile - one CSV upload per
+    table, per the same convention the dataset-import flow already uses
+    (see web_admin_service._parse_dataset_package's csv_by_stem). A single
+    upload is just the len(csv_profiles) == 1 case, not a special path.
+
+    Single LLM call, all tables at once - used when the dataset's combined
+    full-CSV-text fits one call's context budget. Datasets too large for
+    that use build_batch_prompt instead (see draft_service._batch_tables).
+    """
+    system_prompt = _build_system_prompt()
+
+    full_csv_texts = full_csv_texts or {}
+    sections = [f"This dataset has {len(csv_profiles)} table(s), one per uploaded CSV:"]
+    for table_name, profile in csv_profiles.items():
+        sections.append(_format_csv_profile(table_name, profile))
+        full_csv_text = full_csv_texts.get(table_name)
+        if full_csv_text is not None:
+            sections.append(f"Full CSV contents for table '{table_name}':\n" + full_csv_text)
+
+    sections.extend(_digitization_log_sections(digitization_log))
+
+    user_prompt = "\n\n".join(sections)
+    return system_prompt, user_prompt
+
+
+def build_batch_prompt(
+    *,
+    csv_profiles: dict[str, CsvProfile],
+    digitization_log: DigitizationLog | None,
+    full_csv_texts: dict[str, str],
+    batch_table_names: list[str],
+    include_dataset_level_fields: bool,
+) -> tuple[str, str]:
+    """Same task rules/schema as build_prompt (the system prompt never
+    changes per batch) - used when a dataset has too many/large CSVs for
+    one call's context budget (see draft_service._batch_tables). Every
+    table in the dataset is listed by name for cross-table context (so
+    joinKeys/comments/tags stay consistent across calls), but full CSV
+    content - and a `tables:` entry - is requested only for
+    batch_table_names; every table's real content still reaches the LLM,
+    just split across separate calls instead of ever being summarized away.
+
+    Dataset-wide narrative fields (datasetDescription, source, etc.) are
+    requested only when include_dataset_level_fields is True - normally
+    just the first batch - so the results from every batch can be merged
+    into one manifest afterward without conflicting narratives (see
+    draft_service._merge_batch_manifests).
+    """
+    system_prompt = _build_system_prompt()
+
+    all_table_names = list(csv_profiles.keys())
+    batch_set = set(batch_table_names)
+    sections = [
+        f"This dataset has {len(all_table_names)} table(s) total: {', '.join(all_table_names)}.",
+        f"This call covers {len(batch_table_names)} of them: {', '.join(batch_table_names)}. "
+        "Produce a `tables:` entry ONLY for these - the rest are listed below for "
+        "cross-table context (so your joinKeys/comments/tags stay consistent with the "
+        "rest of the dataset) but are drafted in separate calls; do not invent a "
+        "`tables:` entry for any table not in this list.",
+    ]
+    if include_dataset_level_fields:
+        sections.append(
+            "This is the FIRST call for this dataset - also produce the dataset-wide "
+            "fields (datasetDescription, source, spatialCoverage, spatialResolution, "
+            "temporalCoverage, temporalResolution, updateFrequency, references, "
+            "canonicalEnumDefinitions) as normal, based on the tables shown to you here."
+        )
+    else:
+        sections.append(
+            "This is NOT the first call for this dataset - a separate call already "
+            "produced datasetDescription, source, spatialCoverage, spatialResolution, "
+            "temporalCoverage, temporalResolution, updateFrequency, and references. Omit "
+            "those keys entirely from your MANIFEST output. You MAY still include "
+            "joinKeys, tags, comments, and enumDefinitions/canonicalEnumDefinitions "
+            "scoped to the tables shown to you here - these will be merged with the "
+            "other calls' contributions afterward."
+        )
+
+    for table_name, profile in csv_profiles.items():
+        if table_name in batch_set:
+            sections.append(_format_csv_profile(table_name, profile))
+            full_csv_text = full_csv_texts.get(table_name)
+            if full_csv_text is not None:
+                sections.append(f"Full CSV contents for table '{table_name}':\n" + full_csv_text)
+        else:
+            column_names = [col.name for col in profile.columns]
+            sections.append(
+                f"## Table: {table_name} (context only, drafted in a separate call - "
+                f"columns: {column_names})"
+            )
+
+    sections.extend(_digitization_log_sections(digitization_log))
+
+    user_prompt = "\n\n".join(sections)
+    return system_prompt, user_prompt
+
+
+def parse_llm_output(text: str) -> tuple[dict, list[dict]]:
+    """Parses the ---MANIFEST--- / ---FLAGS--- delimited response into
+    (manifest_dict, flags). Raises ValueError on malformed output (missing
+    delimiters, non-mapping YAML, or YAML the LLM produced that doesn't
+    even parse) so the caller can retry once with a corrective follow-up turn.
+    """
+    if "---MANIFEST---" not in text or "---FLAGS---" not in text:
+        raise ValueError("LLM output missing required ---MANIFEST--- / ---FLAGS--- delimiters")
+
+    _, rest = text.split("---MANIFEST---", 1)
+    manifest_text, flags_text = rest.split("---FLAGS---", 1)
+
+    try:
+        manifest_dict = yaml.safe_load(manifest_text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Manifest block is not valid YAML: {exc}") from exc
+    if not isinstance(manifest_dict, dict):
+        raise ValueError("Parsed manifest is not a YAML mapping")
+
+    try:
+        flags_doc = yaml.safe_load(flags_text) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Flags block is not valid YAML: {exc}") from exc
+    flags = flags_doc.get("flags", []) if isinstance(flags_doc, dict) else []
+
+    return manifest_dict, flags

--- a/src/dataio/api/services/draft_review_service.py
+++ b/src/dataio/api/services/draft_review_service.py
@@ -13,6 +13,7 @@ will ever go on to consume it itself.
 
 from __future__ import annotations
 
+import datetime
 import os
 
 import yaml
@@ -56,6 +57,25 @@ def _draft_to_dict(draft, *, dataset_exists: bool | None = None) -> dict:
         "reviewed_at": draft.reviewed_at.isoformat() if draft.reviewed_at else None,
         "superseded_by_draft_id": str(draft.superseded_by_draft_id) if draft.superseded_by_draft_id else None,
     }
+
+
+def _stringify_dates(value):
+    """yaml.safe_load implicitly parses an ISO-8601-looking scalar (e.g. a
+    temporalCoverage value like "2019-06-30") into a datetime.date/datetime
+    object - every manifest field is a plain string everywhere else in the
+    app (CuratorMetadataInput, field_inference, etc. never produce a real
+    date object), and the JSONB column's json serializer has no idea how to
+    write one out, so a curator-edited draft containing one fails to save.
+    Round-trips it back to the plain-string contract the rest of the app
+    expects.
+    """
+    if isinstance(value, dict):
+        return {k: _stringify_dates(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_stringify_dates(v) for v in value]
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    return value
 
 
 class DraftReviewService(BaseService):
@@ -112,6 +132,72 @@ class DraftReviewService(BaseService):
 
         return draft.model_dump()
 
+    def generate_deterministic_draft_from_upload(
+        self,
+        *,
+        csv_files: list[UploadFile],
+        category_id: str,
+        collection_id: str,
+        created_by: str,
+        data_owner_name: str,
+        curator_input: dict,
+        dataset_id: str | None = None,
+    ) -> dict:
+        """Backs the web "Generate deterministic draft" form - the no-LLM
+        self-service path agreed with Lijith (2026-07-24 Data-Platform
+        Discussion). Same upload-then-draft pattern as
+        generate_draft_from_upload, but curator_input (the structured
+        fields a human must supply - see CuratorMetadataInput) takes the
+        place of a digitization log file, and there's no LLM call to make.
+        """
+        from pydantic import ValidationError
+
+        from dataio.api.services.deterministic_draft_service import (
+            CuratorMetadataInput,
+            generate_deterministic_draft,
+        )
+
+        try:
+            parsed_curator_input = CuratorMetadataInput(**curator_input)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid curator_input: {e}") from e
+
+        csv_paths = [save_upload(f) for f in csv_files]
+
+        try:
+            draft = generate_deterministic_draft(
+                csv_paths=csv_paths,
+                category_id=category_id,
+                collection_id=collection_id,
+                created_by=created_by,
+                data_owner_name=data_owner_name,
+                curator_input=parsed_curator_input,
+                dataset_id=dataset_id,
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to generate deterministic manifest draft: {e!s}")
+            raise HTTPException(status_code=502, detail=f"Draft generation failed: {e}") from e
+
+        return draft.model_dump()
+
+    def classify_columns(self, *, column_names: list[str]) -> dict:
+        """Backs the intake form's dynamic per-column description prompts:
+        splits column_names into "fixed" (auto-filled by
+        field_inference.infer_fixed_column_description - never prompted)
+        and "needsDescription" (everything else - the curator must supply
+        one, see deterministic_draft_service.CuratorMetadataInput.
+        columnDescriptions). No CSV read, no LLM call - the same rule both
+        this endpoint and generate_deterministic_draft use, so the intake
+        form and the actual validation can never disagree about which
+        columns require a description. Classification only depends on each
+        column's own name, not which table it's in, so no table_name here.
+        """
+        from dataio.api.services.field_inference import infer_fixed_column_description
+
+        fixed = [name for name in column_names if infer_fixed_column_description(name) is not None]
+        needs_description = [name for name in column_names if name not in fixed]
+        return {"fixed": fixed, "needsDescription": needs_description}
+
     def revalidate_draft(self, draft_id: str) -> dict:
         """Re-runs the same conversion + existing-DataIOValidator check
         generate_draft() used, in case the CSV(s) or the manifest have
@@ -130,6 +216,58 @@ class DraftReviewService(BaseService):
         )
         updated = database.update_manifest_draft_status(
             draft_id, draft.status.value, validation_result=result.model_dump(),
+        )
+        return _draft_to_dict(updated)
+
+    def update_draft_content(self, draft_id: str, draft_yaml: str) -> dict:
+        """Persists curator-edited manifest YAML (the Draft Review screen's
+        inline editor), re-validating against the same real CSVs
+        revalidate_draft uses. Only allowed while a draft is still under
+        review - an approved/rejected draft is final, and its ids may
+        already be in use elsewhere.
+        """
+        from dataio.api.services.draft_service import _reorder_manifest_keys, decode_csv_paths
+
+        draft = self._get_draft_or_404(draft_id)
+        if draft.status.value in ("approved", "rejected"):
+            raise HTTPException(
+                status_code=400, detail=f"Cannot edit a draft that is already {draft.status.value}."
+            )
+
+        try:
+            draft_json = _stringify_dates(yaml.safe_load(draft_yaml))
+        except yaml.YAMLError as exc:
+            raise HTTPException(status_code=400, detail=f"Not valid YAML: {exc}") from exc
+        if not isinstance(draft_json, dict):
+            raise HTTPException(status_code=400, detail="Manifest must be a YAML mapping.")
+
+        table_names = list((draft_json.get("tables") or {}).keys())
+        csv_paths_by_table = decode_csv_paths(draft.source_csv_path, table_names)
+
+        # Re-canonicalize key/column order on every save, not just at
+        # generation time (_finalize_draft) - a full-manifest submission
+        # (the Apply numeric-settings action, a raw YAML edit) round-trips
+        # draft_json through the DB's JSONB column, which does not preserve
+        # object key order at any nesting depth, so without this the saved
+        # draft_yaml would drift away from the hand-authored ordering every
+        # real metadata.yaml uses (see CANONICAL_KEY_ORDER).
+        draft_json = _reorder_manifest_keys(draft_json, csv_paths_by_table)
+        draft_yaml = yaml.safe_dump(draft_json, sort_keys=False, allow_unicode=True)
+
+        contract_manifest = convert_v2_manifest_to_contract(draft_json)
+        manifest_yaml = yaml.safe_dump(contract_manifest, sort_keys=False, allow_unicode=True)
+        data_files = {
+            name: csv_paths_by_table[name] for name in table_names if name in csv_paths_by_table
+        }
+        result = DataIOValidator().validate_tabular(
+            manifest=manifest_yaml, data_files=data_files, deep_check=False, full_scan=True,
+        )
+
+        updated = database.update_manifest_draft_content(
+            draft_id,
+            draft_yaml=draft_yaml,
+            draft_json=draft_json,
+            validation_result=result.model_dump(),
         )
         return _draft_to_dict(updated)
 
@@ -217,28 +355,105 @@ class DraftReviewService(BaseService):
         return _draft_to_dict(updated)
 
     def regenerate_draft(self, draft_id: str, reviewed_by: str) -> dict:
-        """Regenerates the whole draft from the same inputs (CSVs,
-        digitization log, category/collection), superseding the original.
-        Scoping regeneration to a single field is a further refinement not
-        implemented here - this re-runs the full drafting pass.
+        """Regenerates the whole draft from the same inputs, superseding the
+        original. Scoping regeneration to a single field is a further
+        refinement not implemented here - this re-runs the full drafting
+        pass. Dispatches on llm_model_id (None means the original was a
+        deterministic draft - see generate_deterministic_draft_from_upload)
+        since the two paths need different regeneration inputs (a
+        digitization log file vs. a reconstructed CuratorMetadataInput).
         """
         from dataio.api.services.draft_service import decode_csv_paths, generate_draft
 
         original = self._get_draft_or_404(draft_id)
         table_names = list(original.draft_json.get("tables", {}).keys())
         csv_paths_by_table = decode_csv_paths(original.source_csv_path, table_names)
-        new_draft = generate_draft(
+
+        if original.llm_model_id is None:
+            new_draft = self._regenerate_deterministic_draft(
+                original, csv_paths_by_table, reviewed_by
+            )
+        else:
+            new_draft = generate_draft(
+                csv_paths=list(csv_paths_by_table.values()),
+                category_id=original.category_id,
+                collection_id=original.collection_id,
+                created_by=reviewed_by,
+                data_owner_name=original.draft_json.get("datasetOwner", ""),
+                dataset_id=original.dataset_id,
+                digitization_log_path=original.digitization_log_path,
+                superseded_by_draft_id=str(original.draft_id),
+                # Reuse the same reserved rds_id rather than reserving a
+                # second one - this is a redraft of the same dataset, not a
+                # new one.
+                raw_dataset_id=original.raw_dataset_id,
+            )
+        database.update_manifest_draft_status(draft_id, "rejected", reviewed_by=reviewed_by)
+        return new_draft.model_dump()
+
+    def _regenerate_deterministic_draft(self, original, csv_paths_by_table: dict, reviewed_by: str):
+        """Reconstructs a CuratorMetadataInput from the original draft's own
+        draft_json (its top-level curator-owned fields round-trip verbatim)
+        and re-runs generate_deterministic_draft against the same CSVs -
+        the deterministic equivalent of the LLM path's full re-drafting
+        pass. Regenerating with unchanged input reproduces the same output
+        by design (no randomness to re-roll); it only differs from the
+        original if the curator edits fields first via a future intake-form
+        "regenerate with edits" flow.
+
+        Region-history comments (prefixed "[region history]", see
+        region_gap_detector.py) are excluded from the round-tripped
+        `comments` list since generate_deterministic_draft recomputes and
+        re-appends them fresh from region_history.yaml - carrying the old
+        ones forward would duplicate every one of them.
+        """
+        from dataio.api.services.deterministic_draft_service import (
+            CuratorMetadataInput,
+            TagsInput,
+            generate_deterministic_draft,
+        )
+        from dataio.api.services.field_inference import infer_fixed_column_description
+
+        manifest = original.draft_json
+        tags = manifest.get("tags") or {}
+        curator_input = CuratorMetadataInput(
+            datasetDescription=manifest.get("datasetDescription", ""),
+            source=manifest.get("source", []),
+            references=manifest.get("references", []),
+            tags=TagsInput(concept=tags.get("concept", []), epiType=tags.get("epiType", [])),
+            spatialCoverage=manifest.get("spatialCoverage", ""),
+            spatialResolution=manifest.get("spatialResolution", ""),
+            temporalCoverage=manifest.get("temporalCoverage", ""),
+            temporalResolution=manifest.get("temporalResolution", ""),
+            updateFrequency=manifest.get("updateFrequency", ""),
+            comments=[
+                c for c in manifest.get("comments", []) if not c.startswith("[region history]")
+            ],
+            joinKeyColumns=manifest.get("joinKeys", []),
+            tableDescriptions={
+                name: t.get("description", "") for name, t in (manifest.get("tables") or {}).items()
+            },
+            # Fixed-pattern columns (region identifiers, source/provenance)
+            # regenerate fresh from infer_fixed_column_description - only
+            # curator-supplied ones need to round-trip.
+            columnDescriptions={
+                table_name: {
+                    column_name: field.get("description", "")
+                    for column_name, field in (table.get("data_dictionary") or {}).items()
+                    if infer_fixed_column_description(column_name) is None
+                }
+                for table_name, table in (manifest.get("tables") or {}).items()
+            },
+            datasetTitle=manifest.get("datasetTitle", ""),
+        )
+        return generate_deterministic_draft(
             csv_paths=list(csv_paths_by_table.values()),
             category_id=original.category_id,
             collection_id=original.collection_id,
             created_by=reviewed_by,
-            data_owner_name=original.draft_json.get("datasetOwner", ""),
+            data_owner_name=manifest.get("datasetOwner", ""),
+            curator_input=curator_input,
             dataset_id=original.dataset_id,
-            digitization_log_path=original.digitization_log_path,
             superseded_by_draft_id=str(original.draft_id),
-            # Reuse the same reserved rds_id rather than reserving a second
-            # one - this is a redraft of the same dataset, not a new one.
             raw_dataset_id=original.raw_dataset_id,
         )
-        database.update_manifest_draft_status(draft_id, "rejected", reviewed_by=reviewed_by)
-        return new_draft.model_dump()

--- a/src/dataio/api/services/draft_review_service.py
+++ b/src/dataio/api/services/draft_review_service.py
@@ -1,0 +1,244 @@
+"""Curator-facing review gate for LLM-drafted metadata.yaml. This tool only
+generates and validates a draft for download right now - it does not
+upload/persist anything to S3 or Postgres. "Approve" just marks the draft
+as accepted; the draft's dataset_id and raw_dataset_id were already
+reserved at generation time (see draft_service.generate_draft) and stay
+reserved (visible under the admin "Reserved IDs" tab) until some future
+import/upload process consumes them - create_dataset/create_raw_dataset
+already release a matching reservation automatically when that happens.
+Both reject_draft and delete_draft below release any reservation that
+hasn't been consumed yet, since neither leaves the draft as something that
+will ever go on to consume it itself.
+"""
+
+from __future__ import annotations
+
+import os
+
+import yaml
+from fastapi import HTTPException, UploadFile
+
+from dataio.api.database import functions as database
+from dataio.api.database.functions import (
+    check_if_raw_dataset_exists,
+    delete_reserved_dataset_id,
+    delete_reserved_raw_dataset_id,
+)
+from dataio.api.services.base_service import BaseService
+from dataio.api.services.draft_upload_storage import save_upload
+from dataio.api.services.manifest_v2_conversion import convert_v2_manifest_to_contract
+from dataio.validate.sdk import DataIOValidator
+
+
+def _draft_to_dict(draft, *, dataset_exists: bool | None = None) -> dict:
+    return {
+        "draft_id": str(draft.draft_id),
+        "dataset_id": draft.dataset_id,
+        # Whether draft.dataset_id (a reserved ID, set at generation time)
+        # already corresponds to a real Dataset row. A draft always has a
+        # dataset_id now, so the frontend can't tell "brand new" from
+        # "existing" just by checking for null anymore - it needs this.
+        "dataset_exists": dataset_exists,
+        "collection_id": draft.collection_id,
+        "category_id": draft.category_id,
+        "source_csv_path": draft.source_csv_path,
+        "digitization_log_path": draft.digitization_log_path,
+        "status": draft.status.value,
+        "draft_yaml": draft.draft_yaml,
+        "draft_json": draft.draft_json,
+        "flagged_fields": draft.flagged_fields,
+        "reviewer_notes": draft.reviewer_notes,
+        "validation_result": draft.validation_result,
+        "llm_model_id": draft.llm_model_id,
+        "created_by": draft.created_by,
+        "created_at": draft.created_at.isoformat() if draft.created_at else None,
+        "reviewed_by": draft.reviewed_by,
+        "reviewed_at": draft.reviewed_at.isoformat() if draft.reviewed_at else None,
+        "superseded_by_draft_id": str(draft.superseded_by_draft_id) if draft.superseded_by_draft_id else None,
+    }
+
+
+class DraftReviewService(BaseService):
+    def _get_draft_or_404(self, draft_id: str):
+        draft = database.get_manifest_draft(draft_id)
+        if not draft:
+            raise HTTPException(status_code=404, detail=f"Manifest draft {draft_id} not found")
+        return draft
+
+    def list_drafts(self, status: str | None = None, dataset_id: str | None = None, limit: int = 50, offset: int = 0):
+        drafts, total = database.list_manifest_drafts(status=status, dataset_id=dataset_id, limit=limit, offset=offset)
+        return {"drafts": [_draft_to_dict(d) for d in drafts], "total": total}
+
+    def get_draft(self, draft_id: str) -> dict:
+        draft = self._get_draft_or_404(draft_id)
+        dataset_exists = database.check_if_dataset_exists(draft.dataset_id) if draft.dataset_id else False
+        return _draft_to_dict(draft, dataset_exists=dataset_exists)
+
+    def generate_draft_from_upload(
+        self,
+        *,
+        csv_files: list[UploadFile],
+        category_id: str,
+        collection_id: str,
+        created_by: str,
+        data_owner_name: str,
+        dataset_id: str | None = None,
+        digitization_log_file: UploadFile | None = None,
+    ) -> dict:
+        """Backs the web "Generate draft" form: persists the uploaded CSVs
+        (and optional digitization log) to local disk - not S3, since a
+        draft is by definition pre-upload - then runs the same
+        generate_draft() the CLI uses. One or more CSVs may be uploaded;
+        each becomes its own table in the drafted manifest.
+        """
+        from dataio.api.services.draft_service import generate_draft
+
+        csv_paths = [save_upload(f) for f in csv_files]
+        digitization_log_path = save_upload(digitization_log_file) if digitization_log_file else None
+
+        try:
+            draft = generate_draft(
+                csv_paths=csv_paths,
+                category_id=category_id,
+                collection_id=collection_id,
+                created_by=created_by,
+                data_owner_name=data_owner_name,
+                dataset_id=dataset_id,
+                digitization_log_path=digitization_log_path,
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to generate manifest draft: {e!s}")
+            raise HTTPException(status_code=502, detail=f"Draft generation failed: {e}") from e
+
+        return draft.model_dump()
+
+    def revalidate_draft(self, draft_id: str) -> dict:
+        """Re-runs the same conversion + existing-DataIOValidator check
+        generate_draft() used, in case the CSV(s) or the manifest have
+        changed since the draft was created (e.g. after a manual edit).
+        """
+        from dataio.api.services.draft_service import decode_csv_paths
+
+        draft = self._get_draft_or_404(draft_id)
+        contract_manifest = convert_v2_manifest_to_contract(draft.draft_json)
+        manifest_yaml = yaml.safe_dump(contract_manifest, sort_keys=False, allow_unicode=True)
+        table_names = list(contract_manifest.get("datasetTables", {}).keys())
+        csv_paths_by_table = decode_csv_paths(draft.source_csv_path, table_names)
+        data_files = {name: csv_paths_by_table[name] for name in table_names if name in csv_paths_by_table}
+        result = DataIOValidator().validate_tabular(
+            manifest=manifest_yaml, data_files=data_files, deep_check=False, full_scan=True,
+        )
+        updated = database.update_manifest_draft_status(
+            draft_id, draft.status.value, validation_result=result.model_dump(),
+        )
+        return _draft_to_dict(updated)
+
+    def _release_reservations(self, draft) -> None:
+        """Releases draft.dataset_id and draft.raw_dataset_id, but only the
+        ones that are still just reservations (no real Dataset/RawDataset
+        row exists yet) - a draft whose ids were already consumed by real
+        rows must not have those rows' ids touched. Shared by delete_draft
+        and reject_draft: neither leaves the draft in a state that will
+        ever go on to consume the reservation itself, so both must free it
+        up rather than let it sit unused forever.
+        """
+        if draft.dataset_id and not database.check_if_dataset_exists(draft.dataset_id):
+            try:
+                delete_reserved_dataset_id(draft.dataset_id)
+            except ValueError:
+                pass  # already released, or never actually reserved - fine either way
+        if draft.raw_dataset_id and not check_if_raw_dataset_exists(draft.raw_dataset_id):
+            try:
+                delete_reserved_raw_dataset_id(draft.raw_dataset_id)
+            except ValueError:
+                pass
+
+    def _delete_uploaded_files(self, draft) -> None:
+        """Best-effort cleanup of the CSV(s)/digitization log save_upload()
+        wrote to local disk for this draft - delete_manifest_draft only
+        removes the DB row, so without this every generated-then-deleted
+        draft would leak its uploaded files on disk indefinitely.
+        """
+        from dataio.api.services.draft_service import decode_csv_paths
+
+        table_names = list((draft.draft_json or {}).get("tables", {}).keys())
+        paths = list(decode_csv_paths(draft.source_csv_path, table_names).values())
+        if draft.digitization_log_path:
+            paths.append(draft.digitization_log_path)
+        for path in paths:
+            try:
+                os.remove(path)
+            except OSError:
+                pass  # already gone, or never existed - not worth failing the delete over
+
+    def delete_draft(self, draft_id: str) -> None:
+        """Removes a draft row outright. Never touches anything already
+        approved and persisted - approval writes through the existing
+        filestore/datasets path, entirely separate from this table.
+
+        Also releases any reservation (dataset_id and/or raw_dataset_id)
+        this draft was the only thing holding, and cleans up its uploaded
+        source files - otherwise a deleted, unwanted draft would
+        permanently squat on those IDs and leak disk space.
+        """
+        draft = self._get_draft_or_404(draft_id)
+        self._release_reservations(draft)
+        self._delete_uploaded_files(draft)
+        database.delete_manifest_draft(draft_id)
+
+    def approve_draft(self, draft_id: str, reviewed_by: str) -> dict:
+        """Marks a draft as accepted. Does not upload or persist anything -
+        this tool only generates and validates a draft for download right
+        now. The dataset_id and raw_dataset_id were already reserved at
+        generation time and simply stay reserved; nothing further needs to
+        happen here for them to show up under "Reserved IDs".
+        """
+        self._get_draft_or_404(draft_id)
+        updated = database.update_manifest_draft_status(draft_id, "approved", reviewed_by=reviewed_by)
+        return _draft_to_dict(updated)
+
+    def reject_draft(self, draft_id: str, reviewed_by: str, reason: str | None = None) -> dict:
+        """Marks a draft as rejected and releases any reservation it was
+        holding - a rejected draft (unlike one mid-regeneration, see
+        regenerate_draft) is not going to go on to consume that id itself,
+        so holding onto it would permanently and pointlessly skip that
+        number in the global/category counter.
+        """
+        draft = self._get_draft_or_404(draft_id)
+        if reason:
+            database.append_manifest_draft_note(draft_id, {"note": reason, "by": reviewed_by})
+        self._release_reservations(draft)
+        updated = database.update_manifest_draft_status(draft_id, "rejected", reviewed_by=reviewed_by)
+        return _draft_to_dict(updated)
+
+    def flag_field(self, draft_id: str, field_path: str, note: str, reviewed_by: str) -> dict:
+        self._get_draft_or_404(draft_id)
+        updated = database.flag_manifest_draft_field(draft_id, field_path, note, reviewed_by)
+        return _draft_to_dict(updated)
+
+    def regenerate_draft(self, draft_id: str, reviewed_by: str) -> dict:
+        """Regenerates the whole draft from the same inputs (CSVs,
+        digitization log, category/collection), superseding the original.
+        Scoping regeneration to a single field is a further refinement not
+        implemented here - this re-runs the full drafting pass.
+        """
+        from dataio.api.services.draft_service import decode_csv_paths, generate_draft
+
+        original = self._get_draft_or_404(draft_id)
+        table_names = list(original.draft_json.get("tables", {}).keys())
+        csv_paths_by_table = decode_csv_paths(original.source_csv_path, table_names)
+        new_draft = generate_draft(
+            csv_paths=list(csv_paths_by_table.values()),
+            category_id=original.category_id,
+            collection_id=original.collection_id,
+            created_by=reviewed_by,
+            data_owner_name=original.draft_json.get("datasetOwner", ""),
+            dataset_id=original.dataset_id,
+            digitization_log_path=original.digitization_log_path,
+            superseded_by_draft_id=str(original.draft_id),
+            # Reuse the same reserved rds_id rather than reserving a second
+            # one - this is a redraft of the same dataset, not a new one.
+            raw_dataset_id=original.raw_dataset_id,
+        )
+        database.update_manifest_draft_status(draft_id, "rejected", reviewed_by=reviewed_by)
+        return new_draft.model_dump()

--- a/src/dataio/api/services/draft_review_service.py
+++ b/src/dataio/api/services/draft_review_service.py
@@ -198,6 +198,56 @@ class DraftReviewService(BaseService):
         needs_description = [name for name in column_names if name not in fixed]
         return {"fixed": fixed, "needsDescription": needs_description}
 
+    def infer_dataset_coverage(self, csv_paths: list[str]) -> dict:
+        """Suggests spatialCoverage/spatialResolution/temporalCoverage for
+        the deterministic intake form, from the CSVs' own profiled
+        structure (field_inference.py) - a deterministic starting point
+        the curator reviews and can freely edit or correct on the form;
+        generate_deterministic_draft never re-derives these itself, only
+        ever uses whatever the curator actually submitted. None for a
+        field this couldn't confidently derive - the curator fills that
+        one in manually, same as before this existed. Combines across
+        multiple CSVs (a multi-table dataset): spatialCoverage is "India"
+        if any table has one; spatialResolution is the single finest
+        resolution found across every table; temporalCoverage is the
+        union of every table's observed years.
+        """
+        from dataio.api.services.csv_profiler import profile_csv
+        from dataio.api.services.field_inference import (
+            SPATIAL_RESOLUTION_RANK,
+            infer_data_dictionary,
+            suggest_spatial_coverage,
+            suggest_spatial_resolution,
+            suggest_temporal_coverage,
+        )
+
+        spatial_coverage: str | None = None
+        resolutions: list[str] = []
+        years: set[str] = set()
+        for path in csv_paths:
+            data_dictionary, _ = infer_data_dictionary(profile_csv(path))
+            spatial_coverage = spatial_coverage or suggest_spatial_coverage(data_dictionary)
+            resolution = suggest_spatial_resolution(data_dictionary)
+            if resolution:
+                resolutions.append(resolution)
+            coverage = suggest_temporal_coverage(data_dictionary)
+            if coverage:
+                years.update(y.strip() for y in coverage.split(","))
+
+        # Unrecognized prefixes rank as finer than any known one (matches
+        # suggest_spatial_resolution's own convention within a single table).
+        unknown_rank = max(SPATIAL_RESOLUTION_RANK.values()) + 1
+        spatial_resolution = (
+            max(resolutions, key=lambda r: SPATIAL_RESOLUTION_RANK.get(r, unknown_rank)) if resolutions else None
+        )
+        temporal_coverage = ", ".join(sorted(years)) if years else None
+
+        return {
+            "spatialCoverage": spatial_coverage,
+            "spatialResolution": spatial_resolution,
+            "temporalCoverage": temporal_coverage,
+        }
+
     def revalidate_draft(self, draft_id: str) -> dict:
         """Re-runs the same conversion + existing-DataIOValidator check
         generate_draft() used, in case the CSV(s) or the manifest have

--- a/src/dataio/api/services/draft_review_service.py
+++ b/src/dataio/api/services/draft_review_service.py
@@ -271,6 +271,37 @@ class DraftReviewService(BaseService):
         )
         return _draft_to_dict(updated)
 
+    def generate_info_yaml(self, draft_id: str, access_level: str) -> dict:
+        """Backs the Draft Review screen's "Generate info.yml" action -
+        derives the second file (alongside metadata.yaml) the real
+        dataset-import step expects from fields already on this draft
+        (see info_yaml_builder for what's derived vs. what access_level
+        alone supplies). Deliberately non-persisting, same as
+        suggest_draft_descriptions used to be - just returns text for the
+        curator to download; nothing is saved on the draft itself.
+
+        Only allowed once a draft is approved - the manifest is frozen at
+        that point (update_draft_content refuses further edits), so this
+        is the first moment info.yml's derived fields are guaranteed to
+        reflect the curator's actual final review rather than a
+        still-changeable in-progress draft.
+        """
+        from dataio.api.services.info_yaml_builder import build_info_yaml
+
+        draft = self._get_draft_or_404(draft_id)
+        if draft.status.value != "approved":
+            raise HTTPException(
+                status_code=400, detail="Approve this draft before generating info.yml."
+            )
+        info_yaml = build_info_yaml(
+            draft.draft_json,
+            dataset_id=draft.dataset_id,
+            collection_id=draft.collection_id,
+            raw_dataset_id=draft.raw_dataset_id,
+            access_level=access_level,
+        )
+        return {"info_yaml": info_yaml}
+
     def _release_reservations(self, draft) -> None:
         """Releases draft.dataset_id and draft.raw_dataset_id, but only the
         ones that are still just reservations (no real Dataset/RawDataset

--- a/src/dataio/api/services/draft_service.py
+++ b/src/dataio/api/services/draft_service.py
@@ -620,6 +620,30 @@ def _merge_narrative_into_base(base: dict, narrative_manifest: dict) -> dict:
     return merged
 
 
+def build_csv_paths_by_table(csv_paths: list[str]) -> dict[str, str]:
+    """One table per CSV, keyed by that CSV's own filename stem verbatim -
+    same convention the dataset-import flow already uses (csv_by_stem in
+    web_admin_service._parse_dataset_package). Shared by both drafting
+    paths (see deterministic_draft_service.generate_deterministic_draft).
+
+    Rejects duplicate stems up front (e.g. two CSVs both named "data.csv"
+    from different folders, or the same file picked twice) - a bare dict
+    comprehension would otherwise silently drop all but the last one with
+    no error, and the curator would have no idea a table went missing.
+    """
+    stems = [Path(p).stem for p in csv_paths]
+    duplicates = sorted({stem for stem in stems if stems.count(stem) > 1})
+    if duplicates:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Duplicate table name(s) from CSV filenames: {', '.join(duplicates)}. "
+                "Rename the files so each table name is unique."
+            ),
+        )
+    return {Path(p).stem: str(p) for p in csv_paths}
+
+
 def generate_draft(
     *,
     csv_paths: list[str],
@@ -635,10 +659,7 @@ def generate_draft(
     if not csv_paths:
         raise HTTPException(status_code=400, detail="At least one CSV file is required.")
 
-    # One table per CSV, keyed by that CSV's own filename stem verbatim -
-    # same convention the dataset-import flow already uses (csv_by_stem in
-    # web_admin_service._parse_dataset_package).
-    csv_paths_by_table = {Path(p).stem: str(p) for p in csv_paths}
+    csv_paths_by_table = build_csv_paths_by_table(csv_paths)
     csv_profiles = {table_name: profile_csv(p) for table_name, p in csv_paths_by_table.items()}
     digitization_log = load_digitization_log(digitization_log_path)
 

--- a/src/dataio/api/services/draft_service.py
+++ b/src/dataio/api/services/draft_service.py
@@ -26,9 +26,15 @@ from dataio.api.database.functions import (
     suggest_next_dataset_id,
 )
 from dataio.api.database.rds_id_helpers import resolve_rds_id
-from dataio.api.services.csv_profiler import CsvProfile, profile_csv, read_full_csv_text
+from dataio.api.services.csv_profiler import CsvProfile, profile_csv
 from dataio.api.services.digitization_log import load_digitization_log
-from dataio.api.services.draft_prompt import build_batch_prompt, build_prompt, parse_llm_output
+from dataio.api.services.draft_prompt import (
+    build_batch_prompt,
+    build_prompt,
+    estimate_table_context_size,
+    parse_llm_output,
+)
+from dataio.api.services.field_inference import infer_fixed_column_description, infer_table_structure
 from dataio.api.services.manifest_v2_conversion import convert_v2_manifest_to_contract
 from dataio.api.services.openrouter_draft_client import OpenRouterDraftClient
 from dataio.validate.sdk import DataIOValidator
@@ -197,32 +203,34 @@ def _complete_with_retry(client: OpenRouterDraftClient, system_prompt: str, user
     raise last_error  # every attempt failed to parse; surface the last error
 
 
-# Target combined full-CSV-text size per LLM call, well under Claude Sonnet
-# 5's ~200K token (~800K char) context window - leaves generous headroom for
-# the fixed system prompt (~21K chars), each table's profile overhead
-# (column stats, distinct-value lists), and the completion itself. A
-# dataset whose combined full-CSV-text exceeds this is split into multiple
-# calls (see _batch_tables) rather than any table's content ever being
-# summarized away - every table's real content always reaches the LLM.
+# Target combined per-table prompt-context size per LLM call, well under
+# Claude Sonnet 5's ~200K token (~800K char) context window - leaves
+# generous headroom for the fixed system prompt and the completion itself.
+# Each table's context (see draft_prompt.estimate_table_context_size) is
+# bounded by CsvProfile's own caps (up to 200 distinct values, 20 sample
+# rows) regardless of the table's real row count - unlike the raw full-CSV
+# text this budget used to measure, so multi-batch splitting (see
+# _batch_tables) should now only matter for datasets with unusually many
+# tables/columns, not large row counts.
 BATCH_CHAR_BUDGET = 400_000
 
 
 def _batch_tables(
-    table_names: list[str], full_csv_texts: dict[str, str], char_budget: int = BATCH_CHAR_BUDGET
+    table_names: list[str], context_sizes: dict[str, int], char_budget: int = BATCH_CHAR_BUDGET
 ) -> list[list[str]]:
     """Greedily groups table names (in their given order) into batches so
-    each batch's combined full-CSV-text size stays under char_budget. Never
-    drops or shrinks a table's content - only limits how many tables share
-    one LLM call. A single table whose own full text alone exceeds
-    char_budget still gets its own solo batch (its full content is sent
-    regardless, even if that one call ends up over budget - there's no
-    smaller-than-one-table granularity to split further).
+    each batch's combined prompt-context size stays under char_budget.
+    Never drops or shrinks a table's context - only limits how many tables
+    share one LLM call. A single table whose own context alone exceeds
+    char_budget still gets its own solo batch (sent regardless, even if
+    that one call ends up over budget - there's no smaller-than-one-table
+    granularity to split further).
     """
     batches: list[list[str]] = []
     current: list[str] = []
     current_size = 0
     for table_name in table_names:
-        size = len(full_csv_texts.get(table_name, ""))
+        size = context_sizes.get(table_name, 0)
         if current and current_size + size > char_budget:
             batches.append(current)
             current = []
@@ -509,6 +517,109 @@ def _finalize_draft(
     )
 
 
+def _infer_deterministic_base(
+    csv_profiles: dict[str, CsvProfile], csv_paths_by_table: dict[str, str]
+) -> dict:
+    """Runs the same deterministic structure inference the fully rule-based
+    drafter uses (field_inference.infer_table_structure) for every table,
+    before the LLM is ever called - type/nullable/format/joinKeys/
+    canonicalEnumDefinitions/canonical-value-matching and region-history
+    comments are all mechanical functions of the column profile stats
+    profile_csv already computed, not something an LLM needs to read raw
+    CSV text to guess at. Only per-column `description` is left as None
+    here for columns with no fixed, structural description (see
+    infer_fixed_column_description) - the LLM's narrative pass fills those
+    in afterward (see _merge_narrative_into_base).
+    """
+    tables: dict[str, dict] = {}
+    dataset_enum_definitions: dict[str, dict] = {}
+    dataset_canonical_enum_definitions: dict[str, dict] = {}
+    region_gap_comments: list[str] = []
+
+    for table_name, profile in csv_profiles.items():
+        data_dictionary, join_keys, table_region_comments = infer_table_structure(
+            profile,
+            csv_paths_by_table[table_name],
+            dataset_enum_definitions,
+            dataset_canonical_enum_definitions,
+        )
+        for comment in table_region_comments:
+            if comment not in region_gap_comments:
+                region_gap_comments.append(comment)
+
+        for column_name, field in data_dictionary.items():
+            field["description"] = infer_fixed_column_description(column_name)
+
+        tables[table_name] = {"joinKeys": join_keys, "data_dictionary": data_dictionary}
+
+    dataset_join_keys = sorted({column for table in tables.values() for column in table["joinKeys"]})
+
+    return {
+        "tables": tables,
+        "enum_definitions": dataset_enum_definitions,
+        "canonical_enum_definitions": dataset_canonical_enum_definitions,
+        "join_keys": dataset_join_keys,
+        "region_gap_comments": region_gap_comments,
+    }
+
+
+def _merge_narrative_into_base(base: dict, narrative_manifest: dict) -> dict:
+    """Overlays the LLM's narrative-only output (descriptions, enum
+    definitions, dataset/table-level fields, comments) onto `base` - the
+    deterministic type/joinKeys/canonicalEnumDefinitions/region-comments
+    skeleton from _infer_deterministic_base. Column description precedence:
+    a fixed structural description (already set in `base`) always wins;
+    otherwise the LLM's description is used; otherwise a generic stub
+    (matching infer_data_dictionary's own placeholder shape) in case the
+    LLM omits a column it wasn't specifically asked to redo work on.
+    """
+    merged = dict(narrative_manifest)
+    merged["joinKeys"] = base["join_keys"]
+    if base["canonical_enum_definitions"]:
+        merged["canonicalEnumDefinitions"] = base["canonical_enum_definitions"]
+    merged["comments"] = [*base["region_gap_comments"], *(narrative_manifest.get("comments") or [])]
+
+    narrative_tables = narrative_manifest.get("tables") or {}
+    merged_tables: dict[str, dict] = {}
+    for table_name, base_table in base["tables"].items():
+        narrative_table = narrative_tables.get(table_name) or {}
+        data_dictionary = base_table["data_dictionary"]
+        narrative_data_dictionary = narrative_table.get("data_dictionary") or {}
+        for column_name, field in data_dictionary.items():
+            if field.get("description"):
+                continue
+            llm_description = (narrative_data_dictionary.get(column_name) or {}).get("description")
+            field["description"] = llm_description or f"'{column_name}' column."
+        merged_tables[table_name] = {
+            "description": narrative_table.get("description", ""),
+            "source": narrative_table.get("source", ""),
+            "joinKeys": base_table["joinKeys"],
+            "data_dictionary": data_dictionary,
+        }
+    merged["tables"] = merged_tables
+
+    if base["enum_definitions"]:
+        narrative_enum_defs = narrative_manifest.get("enumDefinitions") or {}
+        merged_enum_defs: dict[str, dict] = {}
+        for block, base_def in base["enum_definitions"].items():
+            narrative_def = narrative_enum_defs.get(block) or {}
+            narrative_values = narrative_def.get("values") or {}
+            values = {}
+            for value, base_value in base_def["values"].items():
+                llm_value_description = (narrative_values.get(value) or {}).get("description")
+                values[value] = {
+                    **base_value,
+                    "description": llm_value_description or base_value["description"],
+                }
+            merged_enum_defs[block] = {
+                "description": narrative_def.get("description") or base_def["description"],
+                "values": values,
+            }
+        merged["enumDefinitions"] = merged_enum_defs
+
+    return merged
+
+
 def generate_draft(
     *,
     csv_paths: list[str],
@@ -531,11 +642,19 @@ def generate_draft(
     csv_profiles = {table_name: profile_csv(p) for table_name, p in csv_paths_by_table.items()}
     digitization_log = load_digitization_log(digitization_log_path)
 
-    # Every table's full CSV content is always sent to the LLM, never
-    # summarized - a dataset too large for one call's context budget is
-    # split across multiple calls instead (see _batch_tables).
-    full_csv_texts = {table_name: read_full_csv_text(p) for table_name, p in csv_paths_by_table.items()}
-    batches = _batch_tables(list(csv_paths_by_table.keys()), full_csv_texts, BATCH_CHAR_BUDGET)
+    # Type/nullable/joinKeys/canonicalEnumDefinitions/region-history
+    # comments are all decided deterministically from the column profile
+    # stats before the LLM is ever called - the LLM only drafts
+    # descriptions and enum definitions (see _merge_narrative_into_base).
+    # This also bounds prompt size per table regardless of row count, since
+    # raw CSV text is never sent at all anymore (see estimate_table_context_size).
+    deterministic_base = _infer_deterministic_base(csv_profiles, csv_paths_by_table)
+
+    table_context_sizes = {
+        table_name: estimate_table_context_size(table_name, profile, deterministic_base["tables"][table_name])
+        for table_name, profile in csv_profiles.items()
+    }
+    batches = _batch_tables(list(csv_paths_by_table.keys()), table_context_sizes, BATCH_CHAR_BUDGET)
 
     client = OpenRouterDraftClient()
     try:
@@ -543,7 +662,7 @@ def generate_draft(
             system_prompt, user_prompt = build_prompt(
                 csv_profiles=csv_profiles,
                 digitization_log=digitization_log,
-                full_csv_texts=full_csv_texts,
+                deterministic_base=deterministic_base,
             )
             batch_results = [_complete_with_retry(client, system_prompt, user_prompt)]
         else:
@@ -552,7 +671,7 @@ def generate_draft(
                 system_prompt, user_prompt = build_batch_prompt(
                     csv_profiles=csv_profiles,
                     digitization_log=digitization_log,
-                    full_csv_texts=full_csv_texts,
+                    deterministic_base=deterministic_base,
                     batch_table_names=batch_table_names,
                     include_dataset_level_fields=(batch_index == 0),
                 )
@@ -560,7 +679,8 @@ def generate_draft(
     finally:
         client.close()
 
-    manifest_dict, flags = _merge_batch_manifests(batch_results)
+    narrative_manifest, flags = _merge_batch_manifests(batch_results)
+    manifest_dict = _merge_narrative_into_base(deterministic_base, narrative_manifest)
 
     return _finalize_draft(
         manifest_dict=manifest_dict,

--- a/src/dataio/api/services/draft_service.py
+++ b/src/dataio/api/services/draft_service.py
@@ -8,6 +8,7 @@ regenerate-flagged-field endpoint - there is exactly one implementation of
 
 from __future__ import annotations
 
+import csv
 import json
 import re
 from datetime import date
@@ -25,7 +26,7 @@ from dataio.api.database.functions import (
     suggest_next_dataset_id,
 )
 from dataio.api.database.rds_id_helpers import resolve_rds_id
-from dataio.api.services.csv_profiler import profile_csv, read_full_csv_text
+from dataio.api.services.csv_profiler import CsvProfile, profile_csv, read_full_csv_text
 from dataio.api.services.digitization_log import load_digitization_log
 from dataio.api.services.draft_prompt import build_batch_prompt, build_prompt, parse_llm_output
 from dataio.api.services.manifest_v2_conversion import convert_v2_manifest_to_contract
@@ -49,11 +50,79 @@ CANONICAL_KEY_ORDER = (
     "joinKeys", "comments", "references", "tables",
 )
 
+# Same convention, one level down: a tables.<name> entry (see e.g.
+# CS0007DS0112's own "tables:" block).
+TABLE_KEY_ORDER = ("description", "source", "joinKeys", "data_dictionary")
 
-def _reorder_manifest_keys(manifest_dict: dict) -> dict:
-    ordered = {key: manifest_dict[key] for key in CANONICAL_KEY_ORDER if key in manifest_dict}
-    remaining = {key: value for key, value in manifest_dict.items() if key not in ordered}
+# Same convention, one level further down: a single data_dictionary.<column>
+# field spec - matches the order field_inference.py naturally builds one in
+# (type/format/enumRef first, then nullable, then description, then
+# isJoinKey/joinKeyType once apply_join_keys runs, then the few
+# curator/review-time additions last).
+FIELD_KEY_ORDER = (
+    "type", "format", "enumRef", "nullable", "description", "isJoinKey",
+    "joinKeyType", "allowedValues", "temporal_axis", "additive", "aggregation", "min",
+)
+
+
+def _reorder_dict(value: dict, key_order: tuple[str, ...]) -> dict:
+    ordered = {key: value[key] for key in key_order if key in value}
+    remaining = {key: val for key, val in value.items() if key not in ordered}
     return {**ordered, **remaining}
+
+
+def _csv_header_columns(csv_path: str) -> list[str]:
+    """Just the header row - the true source of a table's "natural" column
+    order (what infer_data_dictionary produces at generation time, before
+    it's ever round-tripped through the DB). Best-effort: an unreadable/
+    missing path just means column order can't be restored, not that the
+    save should fail.
+    """
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            return next(csv.reader(f))
+    except (OSError, StopIteration):
+        return []
+
+
+def _reorder_manifest_keys(
+    manifest_dict: dict, csv_paths_by_table: dict[str, str] | None = None
+) -> dict:
+    """Restores the hand-authored key/column order at every level of the v2
+    manifest (top-level, each table, each data_dictionary field and its
+    column order) - needed not just once at generation time but on every
+    subsequent save, since a JSONB column (draft_json's storage type) does
+    not preserve object key order at any nesting depth, so a curator-edited
+    draft that round-tripped through the DB would otherwise drift away from
+    this order. csv_paths_by_table is optional and only affects
+    data_dictionary column order (restored to each CSV's own header order);
+    everything else reorders regardless.
+    """
+    ordered = _reorder_dict(manifest_dict, CANONICAL_KEY_ORDER)
+    tables = ordered.get("tables")
+    if isinstance(tables, dict):
+        ordered["tables"] = {
+            name: _reorder_table(table, (csv_paths_by_table or {}).get(name))
+            for name, table in tables.items()
+        }
+    return ordered
+
+
+def _reorder_table(table: dict, csv_path: str | None = None) -> dict:
+    if not isinstance(table, dict):
+        return table
+    reordered = _reorder_dict(table, TABLE_KEY_ORDER)
+    data_dictionary = reordered.get("data_dictionary")
+    if isinstance(data_dictionary, dict):
+        if csv_path:
+            header_columns = _csv_header_columns(csv_path)
+            if header_columns:
+                data_dictionary = _reorder_dict(data_dictionary, tuple(header_columns))
+        reordered["data_dictionary"] = {
+            column: _reorder_dict(field, FIELD_KEY_ORDER) if isinstance(field, dict) else field
+            for column, field in data_dictionary.items()
+        }
+    return reordered
 
 
 def _encode_csv_paths(csv_paths_by_table: dict[str, str]) -> str:
@@ -341,6 +410,105 @@ def _validate_manifest(manifest_dict: dict, csv_paths_by_table: dict[str, str]):
     )
 
 
+def _finalize_draft(
+    *,
+    manifest_dict: dict,
+    flags: list[dict],
+    csv_paths_by_table: dict[str, str],
+    csv_profiles: dict[str, CsvProfile],
+    category_id: str,
+    collection_id: str,
+    created_by: str,
+    data_owner_name: str,
+    dataset_id: str | None,
+    raw_dataset_id: str | None,
+    digitization_log_path: str | None,
+    superseded_by_draft_id: str | None,
+    llm_model_id: str | None,
+) -> DraftRecord:
+    """Shared tail for every draft-generation path (LLM or deterministic):
+    resolves category/collection and ds_id/rds_id, sets the fields no
+    generator has any basis for guessing (datasetID, category, collection,
+    datasetOwner, lastUpdated, datasetSlug), validates against the real CSV
+    data, and persists a pending draft row. Callers only need to have
+    already produced a v2-schema manifest_dict + flags by whatever means
+    (LLM completion, rule-based inference, ...) - everything from here on
+    (ID reservation, key ordering, validation, persistence) is identical
+    regardless of how the manifest content was produced.
+    """
+    all_missing_source_columns = sorted(
+        {column for profile in csv_profiles.values() for column in profile.missing_source_columns}
+    )
+    flags = _ensure_missing_source_columns_flagged(flags, all_missing_source_columns)
+
+    # Validate the collection exists before reserving anything below - a
+    # request for a nonexistent collection must fail with nothing left
+    # reserved behind it.
+    category, collection_field = _resolve_category_and_collection(collection_id)
+
+    # rds_id is tracked on the draft row, not inside the manifest itself -
+    # real metadata.yaml never contains a raw_dataset/rds_id field, that
+    # belongs only in info.yml, generated later. Resolved+reserved (or
+    # reused as-is if raw_dataset_id was passed in, e.g. by regenerate_draft)
+    # the same way resolved_dataset_id is below.
+    rds_id = _resolve_and_reserve_raw_dataset_id(raw_dataset_id, category_id, collection_id, created_by)
+
+    resolved_dataset_id = _resolve_dataset_id(dataset_id, collection_id, created_by)
+
+    # datasetTitle: for a single-CSV dataset, use that CSV's own filename -
+    # matches the established convention (e.g. CS0007DS0112's datasetTitle
+    # is literally "consolidated-livestock-census-1997-2019", its one and
+    # only table/CSV name). With more than one CSV there's no single file to
+    # name it after (e.g. CS0026DS0111's datasetTitle "bahs-milk-production-
+    # statistics-1950-2024" names none of its ~20 table CSVs), so the
+    # generator's own proposed dataset-level title is used instead, falling
+    # back to the first table's name only if none was produced. Set before
+    # building the slug so its fallback has a real title to work from.
+    table_names = list(csv_paths_by_table.keys())
+    if len(table_names) == 1:
+        manifest_dict["datasetTitle"] = table_names[0]
+    else:
+        manifest_dict["datasetTitle"] = manifest_dict.get("datasetTitle") or table_names[0]
+    manifest_dict["datasetID"] = resolved_dataset_id
+    manifest_dict["datasetSlug"] = _build_dataset_slug(
+        resolved_dataset_id, manifest_dict.get("datasetSlug"), manifest_dict.get("datasetTitle")
+    )
+    manifest_dict["metadataSpecVersion"] = METADATA_SPEC_VERSION
+    manifest_dict["category"] = category
+    manifest_dict["collection"] = collection_field
+    manifest_dict["datasetOwner"] = data_owner_name
+    manifest_dict["lastUpdated"] = date.today().isoformat()
+    manifest_dict = _reorder_manifest_keys(manifest_dict)
+
+    manifest_yaml = yaml.safe_dump(manifest_dict, sort_keys=False, allow_unicode=True)
+    validation_result = _validate_manifest(manifest_dict, csv_paths_by_table)
+
+    draft = database.create_manifest_draft(
+        dataset_id=resolved_dataset_id,
+        collection_id=collection_id,
+        category_id=category_id,
+        source_csv_path=_encode_csv_paths(csv_paths_by_table),
+        digitization_log_path=digitization_log_path,
+        raw_dataset_id=rds_id,
+        draft_yaml=manifest_yaml,
+        draft_json=manifest_dict,
+        flagged_fields=flags,
+        validation_result=validation_result.model_dump(),
+        llm_model_id=llm_model_id,
+        created_by=created_by,
+        superseded_by_draft_id=superseded_by_draft_id,
+    )
+
+    return DraftRecord(
+        draft_id=str(draft.draft_id),
+        status=draft.status.value,
+        draft_yaml=draft.draft_yaml,
+        draft_json=draft.draft_json,
+        flagged_fields=draft.flagged_fields,
+        validation_status=validation_result.status,
+    )
+
+
 def generate_draft(
     *,
     csv_paths: list[str],
@@ -394,74 +562,18 @@ def generate_draft(
 
     manifest_dict, flags = _merge_batch_manifests(batch_results)
 
-    all_missing_source_columns = sorted(
-        {column for profile in csv_profiles.values() for column in profile.missing_source_columns}
-    )
-    flags = _ensure_missing_source_columns_flagged(flags, all_missing_source_columns)
-
-    # Validate the collection exists before reserving anything below - a
-    # request for a nonexistent collection must fail with nothing left
-    # reserved behind it.
-    category, collection_field = _resolve_category_and_collection(collection_id)
-
-    # rds_id is tracked on the draft row, not inside the manifest itself -
-    # real metadata.yaml never contains a raw_dataset/rds_id field, that
-    # belongs only in info.yml, generated later. Resolved+reserved (or
-    # reused as-is if raw_dataset_id was passed in, e.g. by regenerate_draft)
-    # the same way resolved_dataset_id is below.
-    rds_id = _resolve_and_reserve_raw_dataset_id(raw_dataset_id, category_id, collection_id, created_by)
-
-    resolved_dataset_id = _resolve_dataset_id(dataset_id, collection_id, created_by)
-
-    # datasetTitle: for a single-CSV dataset, use that CSV's own filename -
-    # matches the established convention (e.g. CS0007DS0112's datasetTitle
-    # is literally "consolidated-livestock-census-1997-2019", its one and
-    # only table/CSV name). With more than one CSV there's no single file to
-    # name it after (e.g. CS0026DS0111's datasetTitle "bahs-milk-production-
-    # statistics-1950-2024" names none of its ~20 table CSVs), so the LLM's
-    # own proposed dataset-level title is used instead, falling back to the
-    # first table's name only if the LLM didn't produce one. Set before
-    # building the slug so its fallback has a real title to work from.
-    table_names = list(csv_paths_by_table.keys())
-    if len(table_names) == 1:
-        manifest_dict["datasetTitle"] = table_names[0]
-    else:
-        manifest_dict["datasetTitle"] = manifest_dict.get("datasetTitle") or table_names[0]
-    manifest_dict["datasetID"] = resolved_dataset_id
-    manifest_dict["datasetSlug"] = _build_dataset_slug(
-        resolved_dataset_id, manifest_dict.get("datasetSlug"), manifest_dict.get("datasetTitle")
-    )
-    manifest_dict["metadataSpecVersion"] = METADATA_SPEC_VERSION
-    manifest_dict["category"] = category
-    manifest_dict["collection"] = collection_field
-    manifest_dict["datasetOwner"] = data_owner_name
-    manifest_dict["lastUpdated"] = date.today().isoformat()
-    manifest_dict = _reorder_manifest_keys(manifest_dict)
-
-    manifest_yaml = yaml.safe_dump(manifest_dict, sort_keys=False, allow_unicode=True)
-    validation_result = _validate_manifest(manifest_dict, csv_paths_by_table)
-
-    draft = database.create_manifest_draft(
-        dataset_id=resolved_dataset_id,
-        collection_id=collection_id,
+    return _finalize_draft(
+        manifest_dict=manifest_dict,
+        flags=flags,
+        csv_paths_by_table=csv_paths_by_table,
+        csv_profiles=csv_profiles,
         category_id=category_id,
-        source_csv_path=_encode_csv_paths(csv_paths_by_table),
-        digitization_log_path=digitization_log_path,
-        raw_dataset_id=rds_id,
-        draft_yaml=manifest_yaml,
-        draft_json=manifest_dict,
-        flagged_fields=flags,
-        validation_result=validation_result.model_dump(),
-        llm_model_id=client.model_id,
+        collection_id=collection_id,
         created_by=created_by,
+        data_owner_name=data_owner_name,
+        dataset_id=dataset_id,
+        raw_dataset_id=raw_dataset_id,
+        digitization_log_path=digitization_log_path,
         superseded_by_draft_id=superseded_by_draft_id,
-    )
-
-    return DraftRecord(
-        draft_id=str(draft.draft_id),
-        status=draft.status.value,
-        draft_yaml=draft.draft_yaml,
-        draft_json=draft.draft_json,
-        flagged_fields=draft.flagged_fields,
-        validation_status=validation_result.status,
+        llm_model_id=client.model_id,
     )

--- a/src/dataio/api/services/draft_service.py
+++ b/src/dataio/api/services/draft_service.py
@@ -1,0 +1,467 @@
+"""Orchestrates a single LLM metadata-drafting run: profile the CSV, load
+the digitization log, build the prompt, call the LLM, parse and validate
+its output, and store the result as a pending draft row. Called by both
+the `dataio draft generate` CLI command and the admin
+regenerate-flagged-field endpoint - there is exactly one implementation of
+"how a draft gets made".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date
+from pathlib import Path
+
+import yaml
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from dataio.api.database import functions as database
+from dataio.api.database.functions import (
+    create_reserved_dataset_id,
+    create_reserved_raw_dataset_id,
+    get_collection_by_identifier,
+    suggest_next_dataset_id,
+)
+from dataio.api.database.rds_id_helpers import resolve_rds_id
+from dataio.api.services.csv_profiler import profile_csv, read_full_csv_text
+from dataio.api.services.digitization_log import load_digitization_log
+from dataio.api.services.draft_prompt import build_batch_prompt, build_prompt, parse_llm_output
+from dataio.api.services.manifest_v2_conversion import convert_v2_manifest_to_contract
+from dataio.api.services.openrouter_draft_client import OpenRouterDraftClient
+from dataio.validate.sdk import DataIOValidator
+
+# Every real metadata.yaml uses this literal value - it's a schema version
+# marker, not something that varies per dataset or that the LLM has any
+# basis for guessing.
+METADATA_SPEC_VERSION = "v2"
+
+# Matches the key order every real metadata.yaml uses (see e.g.
+# CS0007DS0112) - the deterministic fields (datasetID, category, etc.) get
+# set on the dict after the LLM responds, which would otherwise leave them
+# appended at the end rather than in their conventional position.
+CANONICAL_KEY_ORDER = (
+    "datasetTitle", "datasetSlug", "datasetID", "metadataSpecVersion", "source",
+    "category", "collection", "datasetDescription", "datasetOwner", "tags",
+    "spatialCoverage", "spatialResolution", "temporalCoverage", "temporalResolution",
+    "updateFrequency", "lastUpdated", "canonicalEnumDefinitions", "enumDefinitions",
+    "joinKeys", "comments", "references", "tables",
+)
+
+
+def _reorder_manifest_keys(manifest_dict: dict) -> dict:
+    ordered = {key: manifest_dict[key] for key in CANONICAL_KEY_ORDER if key in manifest_dict}
+    remaining = {key: value for key, value in manifest_dict.items() if key not in ordered}
+    return {**ordered, **remaining}
+
+
+def _encode_csv_paths(csv_paths_by_table: dict[str, str]) -> str:
+    """The draft row's source_csv_path column is a single Text field, but a
+    draft can now span multiple CSVs (one per table) - JSON-encode the
+    table_name -> path mapping into it rather than adding a migration for
+    what's still logically "where did this draft's source data come from".
+    """
+    return json.dumps(csv_paths_by_table)
+
+
+def decode_csv_paths(source_csv_path: str, table_names: list[str] | None = None) -> dict[str, str]:
+    """Inverse of _encode_csv_paths. Falls back to treating source_csv_path
+    as a single bare path (pre-multi-CSV drafts, which only ever had one
+    table) paired with the first known table name.
+    """
+    try:
+        decoded = json.loads(source_csv_path)
+        if isinstance(decoded, dict):
+            return decoded
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return {table_names[0]: source_csv_path} if table_names else {}
+
+
+class DraftRecord(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+
+    draft_id: str
+    status: str
+    draft_yaml: str
+    draft_json: dict
+    flagged_fields: list[dict]
+    validation_status: str
+
+
+MAX_COMPLETION_ATTEMPTS = 3
+
+
+def _complete_with_retry(client: OpenRouterDraftClient, system_prompt: str, user_prompt: str) -> tuple[dict, list]:
+    """Calls the LLM and parses its output, retrying with a corrective
+    follow-up turn (up to MAX_COMPLETION_ATTEMPTS total calls) if the
+    response isn't valid YAML in the expected shape - one-shot completions
+    have no structured-output guarantee via OpenRouter's OpenAI-compatible
+    endpoint, so the parser has to be defensive rather than assume
+    well-formed output, and a single retry isn't always enough (e.g. an
+    unquoted colon inside a free-text value can slip past one correction
+    and recur in slightly different wording on the next attempt).
+    """
+    prompt = user_prompt
+    last_error: ValueError | None = None
+    for attempt in range(MAX_COMPLETION_ATTEMPTS):
+        completion = client.complete(system_prompt=system_prompt, user_prompt=prompt)
+        try:
+            return parse_llm_output(completion.text)
+        except ValueError as exc:
+            last_error = exc
+            prompt = (
+                user_prompt
+                + "\n\nYour previous response was not in the required "
+                "---MANIFEST---/---FLAGS--- format, or was not valid YAML: "
+                f"{exc}. Resend your answer, following that format exactly, "
+                "with no other commentary. Double-quote any string value "
+                "containing a colon followed by a space (e.g. a table title "
+                "like \"Table 15R: Buffaloes Male Rural\") - an unquoted "
+                "colon+space inside a plain scalar is parsed as a new "
+                "mapping key and breaks the document. Long free-text values "
+                "must be written as a single-line quoted string or a YAML "
+                "block scalar (using '|' or '>'), never as plain multi-line "
+                "text that isn't quoted or block-scalared."
+            )
+    raise last_error  # every attempt failed to parse; surface the last error
+
+
+# Target combined full-CSV-text size per LLM call, well under Claude Sonnet
+# 5's ~200K token (~800K char) context window - leaves generous headroom for
+# the fixed system prompt (~21K chars), each table's profile overhead
+# (column stats, distinct-value lists), and the completion itself. A
+# dataset whose combined full-CSV-text exceeds this is split into multiple
+# calls (see _batch_tables) rather than any table's content ever being
+# summarized away - every table's real content always reaches the LLM.
+BATCH_CHAR_BUDGET = 400_000
+
+
+def _batch_tables(
+    table_names: list[str], full_csv_texts: dict[str, str], char_budget: int = BATCH_CHAR_BUDGET
+) -> list[list[str]]:
+    """Greedily groups table names (in their given order) into batches so
+    each batch's combined full-CSV-text size stays under char_budget. Never
+    drops or shrinks a table's content - only limits how many tables share
+    one LLM call. A single table whose own full text alone exceeds
+    char_budget still gets its own solo batch (its full content is sent
+    regardless, even if that one call ends up over budget - there's no
+    smaller-than-one-table granularity to split further).
+    """
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_size = 0
+    for table_name in table_names:
+        size = len(full_csv_texts.get(table_name, ""))
+        if current and current_size + size > char_budget:
+            batches.append(current)
+            current = []
+            current_size = 0
+        current.append(table_name)
+        current_size += size
+    if current:
+        batches.append(current)
+    return batches
+
+
+# Dataset-wide narrative fields only the first batch is asked to produce
+# (see build_batch_prompt) - taken as-is from batch 0's manifest, unchanged.
+_SINGLE_SOURCE_DATASET_FIELDS = (
+    "datasetTitle", "datasetDescription", "spatialCoverage", "spatialResolution",
+    "temporalCoverage", "temporalResolution", "updateFrequency",
+)
+# Dataset-wide list-shaped fields every batch may contribute to - unioned
+# (order-preserving, de-duplicated) across all batches instead of taken
+# from one, since every batch may have relevant additions from its own tables.
+_MERGED_LIST_FIELDS = ("source", "references", "joinKeys", "comments")
+
+
+def _merge_batch_manifests(batch_results: list[tuple[dict, list]]) -> tuple[dict, list]:
+    """Combines each batch's (manifest_dict, flags) - produced by separate
+    LLM calls over disjoint subsets of a dataset's tables (see
+    _batch_tables/build_batch_prompt) - into the single manifest_dict/flags
+    pair the rest of generate_draft expects. `tables:` entries are disjoint
+    per batch (each table is drafted by exactly one batch) so they're
+    simply combined; single-source dataset-wide fields come from the first
+    batch only (the only one asked to produce them); list-shaped and
+    dict-shaped dataset-wide fields are unioned across all batches.
+    """
+    if len(batch_results) == 1:
+        return batch_results[0]
+
+    merged: dict = {field: [] for field in _MERGED_LIST_FIELDS}
+    seen_list_values: dict[str, set] = {field: set() for field in _MERGED_LIST_FIELDS}
+    merged_tags_concept: list = []
+    merged_tags_epi_type: list = []
+    merged_enum_defs: dict = {}
+    merged_canonical_enum_defs: dict = {}
+    merged_tables: dict = {}
+    all_flags: list = []
+
+    for field in _SINGLE_SOURCE_DATASET_FIELDS:
+        value = batch_results[0][0].get(field)
+        if value is not None:
+            merged[field] = value
+
+    for manifest_dict, flags in batch_results:
+        all_flags.extend(flags)
+        merged_tables.update(manifest_dict.get("tables") or {})
+
+        tags = manifest_dict.get("tags") or {}
+        for concept in tags.get("concept") or []:
+            if concept not in merged_tags_concept:
+                merged_tags_concept.append(concept)
+        for epi_type in tags.get("epiType") or []:
+            if epi_type not in merged_tags_epi_type:
+                merged_tags_epi_type.append(epi_type)
+
+        for name, definition in (manifest_dict.get("enumDefinitions") or {}).items():
+            merged_enum_defs.setdefault(name, definition)
+        for name, definition in (manifest_dict.get("canonicalEnumDefinitions") or {}).items():
+            merged_canonical_enum_defs.setdefault(name, definition)
+
+        for field in _MERGED_LIST_FIELDS:
+            for item in manifest_dict.get(field) or []:
+                dedup_key = item if isinstance(item, str) else yaml.safe_dump(item, sort_keys=True)
+                if dedup_key not in seen_list_values[field]:
+                    seen_list_values[field].add(dedup_key)
+                    merged[field].append(item)
+
+    merged["tags"] = {"concept": merged_tags_concept, "epiType": merged_tags_epi_type}
+    if merged_enum_defs:
+        merged["enumDefinitions"] = merged_enum_defs
+    if merged_canonical_enum_defs:
+        merged["canonicalEnumDefinitions"] = merged_canonical_enum_defs
+    merged["tables"] = merged_tables
+
+    return merged, all_flags
+
+
+def _ensure_missing_source_columns_flagged(flags: list[dict], missing_source_columns: list[str]) -> list[dict]:
+    """Belt-and-suspenders: don't rely solely on the LLM having followed the
+    "don't invent source facts" instruction. Any column profile_csv found
+    missing gets a flag added deterministically if the LLM didn't already
+    add one for that field.
+    """
+    already_flagged = {f.get("field") for f in flags}
+    for column in missing_source_columns:
+        if column not in already_flagged:
+            flags.append({"field": column, "reason": f"'{column}' is not present in the source CSV."})
+    return flags
+
+
+def _resolve_category_and_collection(collection_id: str) -> tuple[dict, dict]:
+    """Real metadata.yaml files need category/collection ID *and* a real
+    display name (e.g. category.name "Census and Surveys") - not something
+    the LLM can know. Looked up from the same collections table the rest
+    of the admin UI already uses, deterministically, like datasetID.
+    """
+    collection = get_collection_by_identifier(collection_id)
+    if not collection:
+        raise HTTPException(status_code=400, detail=f"Collection '{collection_id}' does not exist.")
+    category = {"ID": collection.category_id, "name": collection.category_name}
+    collection_field = {"ID": collection.collection_id, "name": collection.collection_name}
+    return category, collection_field
+
+
+def _resolve_dataset_id(dataset_id: str | None, collection_id: str, created_by: str) -> str:
+    """Existing dataset_id is used as-is (updating that dataset's metadata).
+    Otherwise mints and reserves a new one now, not at approval time - the
+    validator requires a real, correctly-formatted datasetID on every
+    manifest it checks, draft or not. Reserving it (not just computing it)
+    stops two concurrent draft generations from being handed the same ID;
+    create_dataset already releases the reservation automatically once the
+    dataset is actually created.
+    """
+    if dataset_id:
+        return dataset_id
+    new_id = suggest_next_dataset_id(collection_id)
+    create_reserved_dataset_id(new_id, collection_id, "Reserved for LLM-drafted metadata.yaml", created_by)
+    return new_id
+
+
+def _resolve_and_reserve_raw_dataset_id(
+    raw_dataset_id: str | None, category_id: str, collection_id: str, created_by: str
+) -> str:
+    """Same pattern as _resolve_dataset_id, for rds_id: an existing
+    raw_dataset_id (passed by regenerate_draft, reusing the original
+    draft's id) is used as-is; otherwise a fresh one is resolved and
+    reserved immediately - suggest_next_raw_dataset_id_for_category alone
+    has no side effects (it also backs the read-only "Next ID" admin tool,
+    which must never reserve anything), so two concurrent draft generations
+    in the same category would otherwise be handed the same suggestion.
+    """
+    if raw_dataset_id:
+        return raw_dataset_id
+    new_id = resolve_rds_id({"category": {"ID": category_id}, "collection": {"ID": collection_id}})
+    create_reserved_raw_dataset_id(new_id, category_id, "Reserved for LLM-drafted metadata.yaml", created_by)
+    return new_id
+
+
+_SLUG_ID_PREFIX_RE = re.compile(r"^[a-z]{2}\d{4}ds\d{4}-?", re.IGNORECASE)
+_NON_SLUG_CHARS_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    return _NON_SLUG_CHARS_RE.sub("-", text.lower()).strip("-")
+
+
+def _build_dataset_slug(dataset_id: str, llm_slug: str | None, dataset_title: str | None) -> str:
+    """Deterministically builds a slug matching the validator's
+    ^[a-z]{2}\\d{4}ds\\d{4}-[a-z0-9-]+$ pattern, rather than trusting the LLM
+    to reproduce that exact shape (including an ID it was told not to
+    guess at). Uses whatever descriptive words the LLM provided, stripping
+    any dataset-ID-looking prefix it may have added anyway.
+    """
+    candidate = _SLUG_ID_PREFIX_RE.sub("", (llm_slug or "").strip())
+    suffix = _slugify(candidate) or _slugify(dataset_title or "") or "dataset"
+    return f"{dataset_id.lower()}-{suffix}"
+
+
+def _validate_manifest(manifest_dict: dict, csv_paths_by_table: dict[str, str]):
+    """Converts the v2-schema draft (tables/data_dictionary) into the shape
+    DataIOValidator expects (datasetTables/dataDictionary) and validates
+    with that SAME existing validator - the one every real dataset in this
+    system was actually checked against (confirmed by converting the real
+    CS0007DS0112 metadata.yaml this exact way and comparing it to the live
+    manifest_yaml already stored in Postgres for that dataset: identical
+    shape). No separate/parallel validator. One data file per table, keyed
+    by table name (a dataset may have more than one CSV/table).
+    """
+    contract_manifest = convert_v2_manifest_to_contract(manifest_dict)
+    manifest_yaml = yaml.safe_dump(contract_manifest, sort_keys=False, allow_unicode=True)
+    table_names = list(contract_manifest.get("datasetTables", {}).keys())
+    data_files = {name: csv_paths_by_table[name] for name in table_names if name in csv_paths_by_table}
+    return DataIOValidator().validate_tabular(
+        manifest=manifest_yaml,
+        data_files=data_files,
+        deep_check=False,
+        full_scan=True,
+    )
+
+
+def generate_draft(
+    *,
+    csv_paths: list[str],
+    category_id: str,
+    collection_id: str,
+    created_by: str,
+    data_owner_name: str,
+    dataset_id: str | None = None,
+    digitization_log_path: str | None = None,
+    superseded_by_draft_id: str | None = None,
+    raw_dataset_id: str | None = None,
+) -> DraftRecord:
+    if not csv_paths:
+        raise HTTPException(status_code=400, detail="At least one CSV file is required.")
+
+    # One table per CSV, keyed by that CSV's own filename stem verbatim -
+    # same convention the dataset-import flow already uses (csv_by_stem in
+    # web_admin_service._parse_dataset_package).
+    csv_paths_by_table = {Path(p).stem: str(p) for p in csv_paths}
+    csv_profiles = {table_name: profile_csv(p) for table_name, p in csv_paths_by_table.items()}
+    digitization_log = load_digitization_log(digitization_log_path)
+
+    # Every table's full CSV content is always sent to the LLM, never
+    # summarized - a dataset too large for one call's context budget is
+    # split across multiple calls instead (see _batch_tables).
+    full_csv_texts = {table_name: read_full_csv_text(p) for table_name, p in csv_paths_by_table.items()}
+    batches = _batch_tables(list(csv_paths_by_table.keys()), full_csv_texts, BATCH_CHAR_BUDGET)
+
+    client = OpenRouterDraftClient()
+    try:
+        if len(batches) == 1:
+            system_prompt, user_prompt = build_prompt(
+                csv_profiles=csv_profiles,
+                digitization_log=digitization_log,
+                full_csv_texts=full_csv_texts,
+            )
+            batch_results = [_complete_with_retry(client, system_prompt, user_prompt)]
+        else:
+            batch_results = []
+            for batch_index, batch_table_names in enumerate(batches):
+                system_prompt, user_prompt = build_batch_prompt(
+                    csv_profiles=csv_profiles,
+                    digitization_log=digitization_log,
+                    full_csv_texts=full_csv_texts,
+                    batch_table_names=batch_table_names,
+                    include_dataset_level_fields=(batch_index == 0),
+                )
+                batch_results.append(_complete_with_retry(client, system_prompt, user_prompt))
+    finally:
+        client.close()
+
+    manifest_dict, flags = _merge_batch_manifests(batch_results)
+
+    all_missing_source_columns = sorted(
+        {column for profile in csv_profiles.values() for column in profile.missing_source_columns}
+    )
+    flags = _ensure_missing_source_columns_flagged(flags, all_missing_source_columns)
+
+    # Validate the collection exists before reserving anything below - a
+    # request for a nonexistent collection must fail with nothing left
+    # reserved behind it.
+    category, collection_field = _resolve_category_and_collection(collection_id)
+
+    # rds_id is tracked on the draft row, not inside the manifest itself -
+    # real metadata.yaml never contains a raw_dataset/rds_id field, that
+    # belongs only in info.yml, generated later. Resolved+reserved (or
+    # reused as-is if raw_dataset_id was passed in, e.g. by regenerate_draft)
+    # the same way resolved_dataset_id is below.
+    rds_id = _resolve_and_reserve_raw_dataset_id(raw_dataset_id, category_id, collection_id, created_by)
+
+    resolved_dataset_id = _resolve_dataset_id(dataset_id, collection_id, created_by)
+
+    # datasetTitle: for a single-CSV dataset, use that CSV's own filename -
+    # matches the established convention (e.g. CS0007DS0112's datasetTitle
+    # is literally "consolidated-livestock-census-1997-2019", its one and
+    # only table/CSV name). With more than one CSV there's no single file to
+    # name it after (e.g. CS0026DS0111's datasetTitle "bahs-milk-production-
+    # statistics-1950-2024" names none of its ~20 table CSVs), so the LLM's
+    # own proposed dataset-level title is used instead, falling back to the
+    # first table's name only if the LLM didn't produce one. Set before
+    # building the slug so its fallback has a real title to work from.
+    table_names = list(csv_paths_by_table.keys())
+    if len(table_names) == 1:
+        manifest_dict["datasetTitle"] = table_names[0]
+    else:
+        manifest_dict["datasetTitle"] = manifest_dict.get("datasetTitle") or table_names[0]
+    manifest_dict["datasetID"] = resolved_dataset_id
+    manifest_dict["datasetSlug"] = _build_dataset_slug(
+        resolved_dataset_id, manifest_dict.get("datasetSlug"), manifest_dict.get("datasetTitle")
+    )
+    manifest_dict["metadataSpecVersion"] = METADATA_SPEC_VERSION
+    manifest_dict["category"] = category
+    manifest_dict["collection"] = collection_field
+    manifest_dict["datasetOwner"] = data_owner_name
+    manifest_dict["lastUpdated"] = date.today().isoformat()
+    manifest_dict = _reorder_manifest_keys(manifest_dict)
+
+    manifest_yaml = yaml.safe_dump(manifest_dict, sort_keys=False, allow_unicode=True)
+    validation_result = _validate_manifest(manifest_dict, csv_paths_by_table)
+
+    draft = database.create_manifest_draft(
+        dataset_id=resolved_dataset_id,
+        collection_id=collection_id,
+        category_id=category_id,
+        source_csv_path=_encode_csv_paths(csv_paths_by_table),
+        digitization_log_path=digitization_log_path,
+        raw_dataset_id=rds_id,
+        draft_yaml=manifest_yaml,
+        draft_json=manifest_dict,
+        flagged_fields=flags,
+        validation_result=validation_result.model_dump(),
+        llm_model_id=client.model_id,
+        created_by=created_by,
+        superseded_by_draft_id=superseded_by_draft_id,
+    )
+
+    return DraftRecord(
+        draft_id=str(draft.draft_id),
+        status=draft.status.value,
+        draft_yaml=draft.draft_yaml,
+        draft_json=draft.draft_json,
+        flagged_fields=draft.flagged_fields,
+        validation_status=validation_result.status,
+    )

--- a/src/dataio/api/services/draft_upload_storage.py
+++ b/src/dataio/api/services/draft_upload_storage.py
@@ -1,0 +1,42 @@
+"""Persists CSV/digitization-log uploads from the "Generate draft" web form
+to local disk. Deliberately not S3: a draft is by definition pre-upload -
+the whole point of the review gate is that nothing reaches the real
+filestore until a curator approves it. The path returned here is what gets
+stored as source_csv_path/digitization_log_path on the draft row, and is
+read again on re-validate/regenerate, so it must be stable, not a
+transient tempfile.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+from fastapi import UploadFile
+
+DRAFT_UPLOAD_DIR = os.getenv("DRAFT_UPLOAD_DIR", "data/manifest_draft_uploads")
+
+
+def save_upload(upload_file: UploadFile) -> str:
+    """Writes an uploaded file to DRAFT_UPLOAD_DIR under a UUID-named
+    subdirectory (collision-proof) while preserving the original filename
+    exactly - the filename's stem is used as the table name in the drafted
+    manifest and as the dataset's default title, so it must survive
+    untouched rather than being prefixed with a random ID.
+    """
+    upload_dir = Path(DRAFT_UPLOAD_DIR) / str(uuid.uuid4())
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    # .name strips any directory components (and yields '' for '.'/'..'),
+    # so a crafted filename like '../../etc/passwd' or an absolute path
+    # can't escape upload_dir - the client-supplied filename is otherwise
+    # untrusted input written straight into a server-side file path.
+    original_name = Path(upload_file.filename or "upload").name or "upload"
+    dest_path = upload_dir / original_name
+
+    upload_file.file.seek(0)
+    with open(dest_path, "wb") as f:
+        f.write(upload_file.file.read())
+
+    return str(dest_path.resolve())

--- a/src/dataio/api/services/draft_upload_storage.py
+++ b/src/dataio/api/services/draft_upload_storage.py
@@ -10,6 +10,7 @@ transient tempfile.
 from __future__ import annotations
 
 import os
+import shutil
 import uuid
 from pathlib import Path
 
@@ -35,8 +36,11 @@ def save_upload(upload_file: UploadFile) -> str:
     original_name = Path(upload_file.filename or "upload").name or "upload"
     dest_path = upload_dir / original_name
 
+    # Streamed in chunks (not upload_file.file.read() then write()) - a
+    # large CSV would otherwise be buffered whole in memory before any of
+    # it reaches disk.
     upload_file.file.seek(0)
     with open(dest_path, "wb") as f:
-        f.write(upload_file.file.read())
+        shutil.copyfileobj(upload_file.file, f)
 
     return str(dest_path.resolve())

--- a/src/dataio/api/services/field_inference.py
+++ b/src/dataio/api/services/field_inference.py
@@ -384,3 +384,89 @@ def infer_table_structure(
     region_gap_comments = list(detect_region_gaps_for_table(csv_path, data_dictionary))
 
     return data_dictionary, join_key_columns, region_gap_comments
+
+
+# Coarse-to-fine administrative granularity ranking for the region-name
+# column prefixes real datasets in this system actually use (the LGD
+# convention - see infer_fixed_column_description). Used to pick the
+# FINEST spatial resolution actually present in a table when suggesting
+# spatialResolution to the curator (see suggest_spatial_resolution) - not
+# an exhaustive list of every possible administrative unit, just the ones
+# seen in practice, so an unrecognized prefix still gets returned as its
+# own bare word (see suggest_spatial_resolution), just not preferred over
+# a recognized finer one.
+SPATIAL_RESOLUTION_RANK: dict[str, int] = {
+    "country": 0,
+    "state": 1,
+    "ut": 1,
+    "district": 2,
+    "subdistrict": 3,
+    "block": 3,
+    "taluk": 3,
+    "tehsil": 3,
+    "municipality": 4,
+    "ulb": 4,
+    "town": 5,
+    "village": 5,
+    "ward": 6,
+    "prabhag": 6,
+}
+# Any prefix not in the ranking above is assumed to be at least as fine as
+# the finest recognized one - an unfamiliar administrative unit name is
+# more likely to be a further subdivision this list hasn't caught up with
+# yet than a coarser one, in a system whose real datasets are already
+# state/district-level or finer.
+_UNKNOWN_PREFIX_RANK = max(SPATIAL_RESOLUTION_RANK.values()) + 1
+
+
+def suggest_spatial_resolution(data_dictionary: dict[str, dict]) -> str | None:
+    """Suggests spatialResolution from the finest-grained regionName column
+    actually present (e.g. a "district.name" column present alongside
+    "state.name" means district-level data) - a deterministic starting
+    point for the curator to confirm or correct on the intake form, never
+    trusted as final (generate_deterministic_draft only ever uses the
+    curator's own submitted value, never re-derives this itself). Returns
+    None when no regionName column is present at all.
+    """
+    candidates: list[tuple[int, str]] = []
+    for column_name, field in data_dictionary.items():
+        if field.get("type") != "regionName":
+            continue
+        prefix = column_name.rsplit(".", 1)[0].lower()
+        candidates.append((SPATIAL_RESOLUTION_RANK.get(prefix, _UNKNOWN_PREFIX_RANK), prefix))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda candidate: candidate[0], reverse=True)
+    return candidates[0][1]
+
+
+def suggest_spatial_coverage(data_dictionary: dict[str, dict]) -> str | None:
+    """"India" whenever a state/UT-level region column (regionID or
+    regionName) is present - every real dataset in this system uses the
+    India-specific LGD convention (see infer_fixed_column_description,
+    region_history.yaml). Returns None (curator fills in manually) when no
+    state/UT-level region column is found, rather than guessing at a
+    narrower or altogether different coverage a bare column-name/type
+    check has no real basis for determining.
+    """
+    for column_name, field in data_dictionary.items():
+        if field.get("type") not in ("regionID", "regionName"):
+            continue
+        prefix = column_name.rsplit(".", 1)[0].lower()
+        if prefix in ("state", "ut"):
+            return "India"
+    return None
+
+
+def suggest_temporal_coverage(data_dictionary: dict[str, dict]) -> str | None:
+    """Every actually-observed year, comma-joined - the exact convention
+    real metadata.yaml files use (e.g. "1997, 2003, 2007, 2012, 2019" for
+    irregular census years), read directly off the year-typed column's
+    already-computed allowedValues (see infer_column_type's
+    looks_like_year branch) rather than re-scanning anything. Returns None
+    when no year-typed (date, format "%Y") column is present.
+    """
+    for field in data_dictionary.values():
+        if field.get("type") == "date" and field.get("format") == "%Y" and field.get("allowedValues"):
+            return ", ".join(field["allowedValues"])
+    return None

--- a/src/dataio/api/services/field_inference.py
+++ b/src/dataio/api/services/field_inference.py
@@ -1,0 +1,310 @@
+"""Deterministic (no-LLM) inference of data_dictionary/enumDefinitions
+entries from a CsvProfile.
+
+Implements in code the same rules that, in the LLM drafter, only existed as
+instructions to the model (draft_prompt.py RULES items 5-8: year/date
+columns, regionID/regionName/lgd_code pairing, and enum-vs-string typing).
+Every rule here is a mechanical function of the column's name and its
+profiled statistics (dtype, cardinality, distinct values) - no row-level
+judgment calls beyond what the existing manifest schema conventions already
+fully specify. See the deterministic-metadata-generator plan for context.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dataio.api.services.csv_profiler import ColumnProfile, CsvProfile
+from dataio.api.services.reference_data import load_canonical_enum_registry
+
+_REGION_ID_VALUE_RE = re.compile(r"^[a-z]+_[A-Za-z0-9]+$")
+_YEAR_VALUE_RE = re.compile(r"^\d{4}$")
+# Splits on underscore/hyphen/space AND on camelCase boundaries (same
+# approach as csv_profiler._TOKEN_BOUNDARY_RE) - a column name that's
+# already camelCase (e.g. "sourceDocument", a real column name in the live
+# livestock census CSVs) must round-trip through this unchanged, not get
+# flattened to one token and re-lowercased.
+_WORD_SPLIT_RE = re.compile(r"(?<!^)(?=[A-Z])|[_\-\s]+")
+
+
+def _enum_ref_name(column_name: str) -> str:
+    """Deterministic enumDefinitions block name for a column - the column's
+    own bare name (last dotted segment) in camelCase plus "Enum", e.g.
+    "species" -> "speciesEnum", "table.source_document" -> "sourceDocumentEnum",
+    "sourceDocument" -> "sourceDocumentEnum" (unchanged, not "sourcedocumentEnum").
+    """
+    bare = column_name.rsplit(".", 1)[-1]
+    parts = [p for p in _WORD_SPLIT_RE.split(bare) if p]
+    if not parts:
+        return "valueEnum"
+    camel = parts[0].lower() + "".join(p.capitalize() for p in parts[1:])
+    return f"{camel}Enum"
+
+
+_SOURCE_COLUMN_DESCRIPTIONS = {
+    "sourceDocument": (
+        "URL or filename of the source document from which this row's data was extracted."
+    ),
+    "sourceTableID": (
+        "Identifier of the specific table within the source document this row was extracted from."
+    ),
+    "sourcePage": "Printed page number within the source document where this row's data appears.",
+    "sourcePDFPage": "Absolute PDF page number of the source page within the source document.",
+    "sourceSheetRef": (
+        "Reference to the specific sheet/tab within the source spreadsheet this row came from."
+    ),
+    "sourceGranularity": (
+        "The level of aggregation/detail at which this row's source data was originally reported."
+    ),
+}
+
+
+def infer_fixed_column_description(column_name: str) -> str | None:
+    """Canned description for a column whose name follows a well-known
+    structural convention that means the same thing in every dataset
+    (region identifiers, provenance/source columns) - a curator should
+    never be prompted to describe these. Returns None for anything else
+    (a domain-specific column only a curator can meaningfully describe).
+
+    Deliberately name-only (no CSV values needed, unlike infer_column_type's
+    stricter regionID detection) - this is about whether to prompt the
+    curator at intake time, before any profiling has happened, not about
+    final typing. The two can disagree in rare edge cases (e.g. a
+    non-region "foo.ID" primary-key column skipped here) without breaking
+    anything: a column skipped here just falls back to the generic stub if
+    it turns out to have no curator-supplied description at generation time.
+    """
+    if column_name == "state.ID":
+        return (
+            "LGD-based region identifier in the format state_<lgd_code> for states or "
+            "ut_<lgd_code> for union territories (e.g., state_28, ut_1)."
+        )
+    if column_name == "state.lgd_code":
+        return (
+            "Standard numeric Local Government Directory (LGD) code for the state "
+            "or union territory."
+        )
+    if column_name == "state.name":
+        return "State or union territory name in title case as per LGD."
+    if column_name == "district.ID":
+        return "LGD district code."
+    if column_name == "district.lgd_code":
+        return "Numeric LGD district code extracted from district.ID."
+    if column_name == "district.name":
+        return "District name as per LGD."
+
+    if "." in column_name:
+        prefix, bare_name = column_name.rsplit(".", 1)
+    else:
+        prefix, bare_name = None, column_name
+
+    if column_name.endswith(".ID") and prefix:
+        return f"Prefixed LGD identifier for the {prefix}."
+    if column_name.endswith(".name") and prefix:
+        return f"{prefix.capitalize()} name standardised to LGD classification."
+    if column_name.endswith(".lgd_code") and prefix:
+        return f"Numeric LGD code extracted from {prefix}.ID."
+    if column_name.lower().startswith("source"):
+        return _SOURCE_COLUMN_DESCRIPTIONS.get(bare_name, f"Provenance metadata: {bare_name}.")
+    return None
+
+
+def infer_column_type(column: ColumnProfile) -> dict[str, Any]:
+    """Returns a v2-schema field spec (type, nullable, and format/enumRef
+    as applicable) for one column, using only its name and profiled
+    statistics - the deterministic replacement for the LLM's per-column
+    typing guess.
+    """
+    nullable = column.null_fraction > 0
+    bare_name = column.name.rsplit(".", 1)[-1]
+
+    # A "year" column (bare name, or the final dotted segment, e.g.
+    # "survey.year") - or any column whose every distinct value is a bare
+    # 4-digit number - is a calendar year, never int/string.
+    looks_like_year = bare_name.lower() == "year" or (
+        column.all_distinct_values is not None
+        and len(column.all_distinct_values) > 0
+        and all(_YEAR_VALUE_RE.match(v) for v in column.all_distinct_values)
+    )
+    if looks_like_year:
+        field: dict[str, Any] = {"type": "date", "format": "%Y", "nullable": nullable}
+        if column.all_distinct_values:
+            field["allowedValues"] = sorted(column.all_distinct_values)
+            field["temporal_axis"] = bare_name.lower()
+        return field
+
+    # A `.ID` column is only a regionID if its values already look like
+    # `<lowercase-word>_<code>` (e.g. "state_KA") - a plain numeric or
+    # freeform `.ID` column that doesn't follow that shape is not.
+    if (
+        column.name.endswith(".ID")
+        and column.all_distinct_values is not None
+        and len(column.all_distinct_values) > 0
+        and all(_REGION_ID_VALUE_RE.match(v) for v in column.all_distinct_values)
+    ):
+        return {"type": "regionID", "nullable": nullable}
+    if column.name.endswith(".name"):
+        return {"type": "regionName", "nullable": nullable}
+    if column.name.endswith(".lgd_code"):
+        return {"type": "int", "nullable": nullable}
+
+    # Prefer enum over string for any non-numeric column with a small,
+    # closed set of values - the profiler only populates all_distinct_values
+    # under its cardinality threshold, so "populated" already means "small
+    # enough". A numeric-dtype column (e.g. a page-number column with ~150
+    # distinct values) is never enum just because its cardinality happens to
+    # be low - a closed set of numbers is still a number, not a category -
+    # so it falls through to the int/float branches below regardless.
+    is_numeric_dtype = "int" in column.dtype or "float" in column.dtype
+    if (
+        not is_numeric_dtype
+        and column.all_distinct_values is not None
+        and len(column.all_distinct_values) > 0
+    ):
+        return {"type": "enum", "enumRef": _enum_ref_name(column.name), "nullable": nullable}
+
+    if "int" in column.dtype:
+        return {"type": "int", "nullable": nullable}
+    if "float" in column.dtype:
+        return {"type": "float", "nullable": nullable}
+    return {"type": "string", "nullable": nullable}
+
+
+def build_enum_definition(column: ColumnProfile) -> dict[str, Any]:
+    """A placeholder enumDefinitions entry using each distinct value as its
+    own description - a deterministic starting point for the curator to
+    refine (via the intake form / draft review), not a final answer.
+    """
+    return {
+        "description": f"Values observed in the '{column.name}' column.",
+        "values": {value: {"description": value} for value in (column.all_distinct_values or [])},
+    }
+
+
+def infer_data_dictionary(profile: CsvProfile) -> tuple[dict[str, dict], dict[str, dict]]:
+    """Returns (data_dictionary, enum_definitions) for one table's profile.
+    isJoinKey/joinKeyType are not set here - see apply_join_keys, applied
+    once the composite key for the whole dataset is known.
+    """
+    data_dictionary: dict[str, dict] = {}
+    enum_definitions: dict[str, dict] = {}
+    for column in profile.columns:
+        field = infer_column_type(column)
+        field["description"] = f"'{column.name}' column."
+        if field["type"] == "enum":
+            enum_definitions[field["enumRef"]] = build_enum_definition(column)
+        data_dictionary[column.name] = field
+    return data_dictionary, enum_definitions
+
+
+def find_region_lgd_pairs(
+    profile: CsvProfile, data_dictionary: dict[str, dict]
+) -> list[tuple[str, str]]:
+    """Pairs each regionID-typed column (per the already-inferred
+    data_dictionary, not a fresh guess) with its sibling `<prefix>.lgd_code`
+    column when present - the existing rule that a regionID used as a join
+    key must always be paired with its LGD code column, never included
+    alone.
+    """
+    column_names = {c.name for c in profile.columns}
+    pairs: list[tuple[str, str]] = []
+    for column in profile.columns:
+        if data_dictionary.get(column.name, {}).get("type") != "regionID":
+            continue
+        if not column.name.endswith(".ID"):
+            continue
+        lgd_name = f"{column.name[: -len('.ID')]}.lgd_code"
+        if lgd_name in column_names:
+            pairs.append((column.name, lgd_name))
+    return pairs
+
+
+def infer_join_key_candidates(profile: CsvProfile, data_dictionary: dict[str, dict]) -> list[str]:
+    """Deterministic *suggestion*, not a final decision - meant to be
+    surfaced to the curator as pre-checked candidates in the intake form
+    (this is the one genuinely judgment-based part of manifest drafting, so
+    it's a human confirming a deterministic suggestion rather than an LLM
+    guessing freely). Candidates: every regionID+lgd_code pair (both
+    columns, LGD code first to match existing convention), every date-typed
+    column, and every enum-typed "dimension" column (e.g. species/breed/sex
+    in a livestock census - the grain the row is reported at) - excluding
+    `source*` provenance columns throughout (e.g. a "sourcepdf.year" field
+    recording the source PDF's own publish year, which is constant per
+    document and not a dimension of the data itself; a real column in the
+    live BAHS milk/meat production CSVs, found by running this against
+    every dataset in staging-data/).
+    """
+    candidates: list[str] = []
+    for region_column, lgd_column in find_region_lgd_pairs(profile, data_dictionary):
+        candidates.extend([lgd_column, region_column])
+    for column in profile.columns:
+        field_type = data_dictionary.get(column.name, {}).get("type")
+        is_provenance = column.name.lower().startswith("source")
+        if field_type in {"date", "enum"} and not is_provenance and column.name not in candidates:
+            candidates.append(column.name)
+    return candidates
+
+
+def lookup_canonical_enum_definitions(column_names: list[str]) -> dict[str, dict]:
+    """Matches column (bare) names against canonical_enum_registry.yaml -
+    the deterministic replacement for the LLM's "reuse the INL-98 registry
+    verbatim, never invent a new one for this concept" instruction. Returns
+    a canonicalEnumDefinitions-shaped dict (block name -> definition),
+    including only the blocks whose match keyword actually appears in one
+    of the given column names.
+    """
+    bare_names_lower = {name.rsplit(".", 1)[-1].lower() for name in column_names}
+    result: dict[str, dict] = {}
+    for registry in load_canonical_enum_registry():
+        keywords = [k.lower() for k in registry.get("matchColumnNameContains", [])]
+        if any(keyword in bare_name for keyword in keywords for bare_name in bare_names_lower):
+            result[registry["block"]] = registry["definition"]
+    return result
+
+
+def _normalize_canonical_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def match_canonical_values(
+    distinct_values: list[str], canonical_definition: dict[str, Any]
+) -> dict[str, dict[str, str]]:
+    """Matches a column's observed enum values against one
+    canonicalEnumDefinitions block's values (as returned by
+    lookup_canonical_enum_definitions) by normalized-key equality - e.g. the
+    dataset-local value "crossbred/exotic" matches the canonical key
+    "crossbred_exotic". Returns {value: {"canonical": key, "canonicalRollup":
+    rollup}} only for values that actually match; a value with no
+    normalized match is omitted entirely rather than guessed - a curator
+    can add a real cross-dataset link by hand (via the draft-review YAML
+    editor) for edge cases a string match can't resolve on its own.
+    """
+    canonical_values = canonical_definition.get("values", {})
+    normalized_lookup = {_normalize_canonical_key(key): key for key in canonical_values}
+    result: dict[str, dict[str, str]] = {}
+    for value in distinct_values:
+        canonical_key = normalized_lookup.get(_normalize_canonical_key(value))
+        if canonical_key is None:
+            continue
+        rollup = canonical_values[canonical_key].get("rollup", canonical_key)
+        result[value] = {"canonical": canonical_key, "canonicalRollup": rollup}
+    return result
+
+
+def apply_join_keys(
+    data_dictionary: dict[str, dict], join_key_columns: list[str]
+) -> dict[str, dict]:
+    """Marks each column in join_key_columns with isJoinKey/joinKeyType on
+    its data_dictionary entry (mutates and returns the same dict) - matches
+    the existing manifest convention: joinKeyType "temporal" for a
+    date-typed column, "compositeComponent" otherwise.
+    """
+    for column_name in join_key_columns:
+        field = data_dictionary.get(column_name)
+        if field is None:
+            continue
+        field["isJoinKey"] = True
+        is_temporal = field.get("type") in {"date", "dateTime"}
+        field["joinKeyType"] = "temporal" if is_temporal else "compositeComponent"
+    return data_dictionary

--- a/src/dataio/api/services/field_inference.py
+++ b/src/dataio/api/services/field_inference.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from dataio.api.services.csv_profiler import ColumnProfile, CsvProfile
 from dataio.api.services.reference_data import load_canonical_enum_registry
+from dataio.api.services.region_gap_detector import detect_region_gaps_for_table
 
 _REGION_ID_VALUE_RE = re.compile(r"^[a-z]+_[A-Za-z0-9]+$")
 _YEAR_VALUE_RE = re.compile(r"^\d{4}$")
@@ -308,3 +309,78 @@ def apply_join_keys(
         is_temporal = field.get("type") in {"date", "dateTime"}
         field["joinKeyType"] = "temporal" if is_temporal else "compositeComponent"
     return data_dictionary
+
+
+def infer_table_structure(
+    profile: CsvProfile,
+    csv_path: str,
+    dataset_enum_definitions: dict[str, dict],
+    dataset_canonical_enum_definitions: dict[str, dict],
+    join_key_columns_override: list[str] | None = None,
+) -> tuple[dict[str, dict], list[str], list[str]]:
+    """Returns (data_dictionary, join_keys, region_gap_comments) for one
+    table - every deterministic structure-inference step shared by both the
+    fully-deterministic drafter (generate_deterministic_draft) and the LLM
+    drafter's pre-pass (draft_service._infer_deterministic_base): type
+    inference, enum-block collision-safe merging, canonical-registry
+    cross-linking, join-key resolution, and region-history gap detection.
+    Only per-column `description` text differs between the two callers
+    (curator-supplied vs. LLM-supplied) - left unset here for the caller to
+    fill in afterward.
+
+    Mutates dataset_enum_definitions and dataset_canonical_enum_definitions
+    in place with this table's contributions (collision-safe rename on a
+    genuine enum-block conflict between tables, same as before). Returned
+    region_gap_comments are deduplicated within this table only - a caller
+    combining multiple tables' results is responsible for cross-table
+    dedup, same as before.
+    """
+    data_dictionary, enum_definitions = infer_data_dictionary(profile)
+
+    # Merge this table's enum definitions into the dataset-wide block. Only
+    # rename on a genuine collision (same ref, different values) - two
+    # different tables with a same-named column (e.g. every table has its
+    # own "indicator"/"units"/"sourceTableID") would otherwise silently
+    # overwrite each other's values, failing validation for the earlier
+    # table's rows even though the value was real.
+    for column_name, field in data_dictionary.items():
+        if field.get("type") != "enum":
+            continue
+        enum_ref = field["enumRef"]
+        definition = enum_definitions[enum_ref]
+        existing = dataset_enum_definitions.get(enum_ref)
+        if existing is not None and existing != definition:
+            suffix = 2
+            candidate = f"{enum_ref}{suffix}"
+            while candidate in dataset_enum_definitions and dataset_enum_definitions[candidate] != definition:
+                suffix += 1
+                candidate = f"{enum_ref}{suffix}"
+            enum_ref = candidate
+            field["enumRef"] = enum_ref
+        dataset_enum_definitions[enum_ref] = definition
+
+    column_names = [column.name for column in profile.columns]
+    dataset_canonical_enum_definitions.update(lookup_canonical_enum_definitions(column_names))
+
+    # Cross-link each enum column's observed values to the canonical block
+    # matched for its own name (if any) - e.g. "species" values get
+    # canonical/canonicalRollup keys pointing into
+    # canonicalEnumDefinitions.canonicalSpecies. Values with no normalized
+    # match are left untouched (see match_canonical_values).
+    for column_name, field in data_dictionary.items():
+        if field.get("type") != "enum":
+            continue
+        enum_values = dataset_enum_definitions.get(field["enumRef"], {}).get("values", {})
+        for canonical_definition in lookup_canonical_enum_definitions([column_name]).values():
+            for value, canonical_fields in match_canonical_values(
+                list(enum_values.keys()), canonical_definition
+            ).items():
+                enum_values[value].update(canonical_fields)
+
+    join_key_columns = join_key_columns_override or infer_join_key_candidates(profile, data_dictionary)
+    join_key_columns = [name for name in join_key_columns if name in data_dictionary]
+    apply_join_keys(data_dictionary, join_key_columns)
+
+    region_gap_comments = list(detect_region_gaps_for_table(csv_path, data_dictionary))
+
+    return data_dictionary, join_key_columns, region_gap_comments

--- a/src/dataio/api/services/info_yaml_builder.py
+++ b/src/dataio/api/services/info_yaml_builder.py
@@ -1,0 +1,113 @@
+"""Builds info.yml from an already-generated/approved manifest draft.
+
+info.yml is the second file (alongside metadata.yaml) the real dataset
+import step expects (see web_admin_service._parse_dataset_package) - but
+nothing generates it today, so a curator has to hand-write one from
+scratch after approving a draft, duplicating fields (ds_id, title,
+description, temporal coverage, raw_dataset.source, ...) that already
+exist in draft_json or on the draft row itself. This module derives every
+field it can from those existing, already-curator-reviewed sources -
+access_level is the one field with no source anywhere upstream, so it's
+taken as an explicit parameter (see DraftReviewService.generate_info_yaml).
+
+Deterministic only: string/dict lookups over already-generated
+draft_json - no LLM, no network call, no CSV row/cell data.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+# Matches the key order every hand-authored info.yml uses (see e.g.
+# data/CS0007DS0112-.../info.yml).
+_KEY_ORDER = (
+    "ds_id",
+    "collection_id",
+    "title",
+    "data_owner_name",
+    "description",
+    "temporal_coverage_start_date",
+    "temporal_coverage_end_date",
+    "temporal_resolution",
+    "spatial_resolution",
+    "access_level",
+    "raw_dataset",
+)
+
+# The only date format field_inference.py currently ever produces (see
+# infer_column_type's looks_like_year branch) - extend this mapping if
+# infer_column_type ever learns to type a month/day-level date column.
+_DATE_FORMAT_TO_TEMPORAL_RESOLUTION = {
+    "%Y": "YEAR",
+}
+
+
+def _derive_temporal_coverage(tables: dict | None) -> tuple[str | None, str | None, str | None]:
+    """Scans every table's data_dictionary for a date-typed field with
+    allowedValues (the year field(s) field_inference.py already computes
+    allowedValues/temporal_axis for) and derives (start_date, end_date,
+    temporal_resolution) from the first one found. Datasets in this system
+    only ever have one temporal axis in practice (a single "year" grain
+    shared across all tables), so the first match is taken as authoritative
+    rather than trying to reconcile disagreeing fields across tables.
+    """
+    for table in (tables or {}).values():
+        for field in (table.get("data_dictionary") or {}).values():
+            allowed_values = field.get("allowedValues")
+            if field.get("type") != "date" or not allowed_values:
+                continue
+            start_date = min(allowed_values)
+            end_date = max(allowed_values)
+            resolution = _DATE_FORMAT_TO_TEMPORAL_RESOLUTION.get(field.get("format"))
+            return start_date, end_date, resolution
+    return None, None, None
+
+
+def build_info_yaml(
+    draft_json: dict,
+    *,
+    dataset_id: str,
+    collection_id: str,
+    raw_dataset_id: str | None,
+    access_level: str,
+) -> str:
+    """Deterministic: every field here is a direct lookup/transform of
+    draft_json or the already-resolved draft_id/collection_id/
+    raw_dataset_id - the same fields a curator already reviewed on the
+    Draft Review screen, never a fresh guess. access_level is the sole
+    exception (see module docstring) - passed in by the curator via the
+    review screen, not derivable from anything upstream.
+    """
+    start_date, end_date, temporal_resolution = _derive_temporal_coverage(
+        draft_json.get("tables")
+    )
+    spatial_resolution = draft_json.get("spatialResolution")
+
+    info: dict = {
+        "ds_id": dataset_id,
+        "collection_id": collection_id,
+        "title": draft_json.get("datasetTitle"),
+        "data_owner_name": draft_json.get("datasetOwner"),
+        "description": draft_json.get("datasetDescription"),
+        "temporal_coverage_start_date": start_date,
+        "temporal_coverage_end_date": end_date,
+        "temporal_resolution": temporal_resolution,
+        "spatial_resolution": spatial_resolution.upper() if spatial_resolution else None,
+        "access_level": access_level,
+        "raw_dataset": {
+            "rds_id": raw_dataset_id,
+            "source": "; ".join(draft_json.get("source") or []) or None,
+        },
+    }
+
+    # Drop keys whose value is None - a curator filling these in by hand
+    # should see an absent field to fill in, not `field: null`.
+    ordered = {key: info[key] for key in _KEY_ORDER if key in info and info[key] is not None}
+    if "raw_dataset" in ordered:
+        ordered["raw_dataset"] = {
+            key: value for key, value in ordered["raw_dataset"].items() if value is not None
+        }
+        if not ordered["raw_dataset"]:
+            del ordered["raw_dataset"]
+
+    return yaml.safe_dump(ordered, sort_keys=False, allow_unicode=True)

--- a/src/dataio/api/services/manifest_v2_conversion.py
+++ b/src/dataio/api/services/manifest_v2_conversion.py
@@ -1,0 +1,114 @@
+"""Converts a v2-schema manifest dict (tables/data_dictionary - the real,
+curator-facing metadata.yaml authoring format) into the shape
+dataio.validate.contracts.models.DatasetManifest expects (datasetTables/
+dataDictionary) - so the drafter can be checked with the SAME existing
+DataIOValidator every other dataset in this system was actually validated
+and uploaded through.
+
+This mirrors WebAdminService._build_manifest_field /
+_parse_dataset_package (web_admin_service.py), which does exactly this
+conversion for the dataset-package import flow - confirmed by reading the
+actual live manifest_yaml stored in Postgres for CS0007DS0112: it is in
+the datasetTables shape, not the tables/data_dictionary shape the
+`data/` folder's pre-import staging copy uses. Kept as a standalone module
+rather than imported from web_admin_service.py to avoid touching that
+large, already-relied-upon service class; the two should be kept in sync
+if either changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def convert_v2_field_to_manifest_field(
+    field_name: str,
+    field_spec: dict,
+    enum_scope: dict | None = None,
+) -> dict:
+    field_type = field_spec.get("type")
+    manifest_field: dict[str, Any] = {
+        "description": field_spec.get("description"),
+        "comments": field_spec.get("comments"),
+        "nullable": field_spec.get("nullable", True),
+    }
+    if field_type == "year":
+        manifest_field["type"] = "date"
+        manifest_field["format"] = "%Y"
+    elif field_type == "enum":
+        manifest_field["type"] = "enum"
+        allowed_values = field_spec.get("enum") or field_spec.get("allowedValues")
+        if not allowed_values and field_spec.get("enumRef") and enum_scope:
+            enum_ref = field_spec["enumRef"]
+            nested_definitions = enum_scope.get("enumDefinitions")
+            enum_def = enum_scope.get(enum_ref)
+            if not isinstance(enum_def, dict) and isinstance(nested_definitions, dict):
+                enum_def = nested_definitions.get(enum_ref)
+            if isinstance(enum_def, dict):
+                allowed_values = list((enum_def.get("values") or {}).keys())
+        manifest_field["allowedValues"] = allowed_values or []
+    elif field_type in {"string", "boolean", "int", "float", "regionID", "regionName", "date", "dateTime"}:
+        manifest_field["type"] = field_type
+        if field_spec.get("format"):
+            manifest_field["format"] = field_spec["format"]
+    else:
+        if field_name == "year":
+            manifest_field["type"] = "date"
+            manifest_field["format"] = "%Y"
+        elif field_name.endswith(".ID"):
+            manifest_field["type"] = "regionID"
+        elif field_name.endswith(".name"):
+            manifest_field["type"] = "regionName"
+        else:
+            manifest_field["type"] = "string"
+
+    if field_spec.get("range") is not None:
+        manifest_field["range"] = field_spec["range"]
+    if field_spec.get("min") is not None:
+        manifest_field["min"] = field_spec["min"]
+    if field_spec.get("max") is not None:
+        manifest_field["max"] = field_spec["max"]
+
+    handled_keys = {
+        "type", "description", "comments", "nullable",
+        "enum", "allowedValues", "enumRef", "range", "min", "max",
+    }
+    for key, value in field_spec.items():
+        if key not in handled_keys and key not in manifest_field:
+            manifest_field[key] = value
+    return manifest_field
+
+
+def convert_v2_manifest_to_contract(manifest_dict: dict) -> dict:
+    """manifest_dict is expected to already carry datasetTitle, datasetSlug,
+    datasetID, metadataSpecVersion, category, collection, source,
+    datasetDescription (draft_service.py sets these deterministically) -
+    this only needs to rename tables -> datasetTables (with per-field type
+    conversion) and add datasetKind.
+    """
+    tables = manifest_dict.get("tables") or {}
+    dataset_tables: dict[str, dict] = {}
+
+    for table_name, table in tables.items():
+        table = table or {}
+        data_dictionary = table.get("data_dictionary") or {}
+        dataset_table: dict[str, Any] = {
+            "description": table.get("description"),
+            "source": table.get("source"),
+            "path": f"{table_name}.csv",
+            "dataDictionary": {
+                field_name: convert_v2_field_to_manifest_field(field_name, field_spec, manifest_dict)
+                for field_name, field_spec in data_dictionary.items()
+                if isinstance(field_spec, dict)
+            },
+        }
+        for key, value in table.items():
+            if key not in {"description", "source", "data_dictionary"} and key not in dataset_table:
+                dataset_table[key] = value
+        dataset_tables[table_name] = dataset_table
+
+    return {
+        **{key: value for key, value in manifest_dict.items() if key != "tables"},
+        "datasetKind": "tabular",
+        "datasetTables": dataset_tables,
+    }

--- a/src/dataio/api/services/openrouter_draft_client.py
+++ b/src/dataio/api/services/openrouter_draft_client.py
@@ -1,0 +1,104 @@
+"""One-shot (non-streaming) OpenRouter completion client for the metadata
+drafter. chat_service.py's OpenRouterProvider is async/streaming-only and
+built for the interactive chat agentic loop - not reusable as-is for a
+single-turn drafting call, so this is a small, separate client using the
+same auth/header pattern.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+from pydantic import BaseModel
+
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+# Drafting is a one-shot, long-context, structured-extraction task with a
+# different latency/quality profile than interactive chat, so it gets its
+# own model env var - falls back to the chat service's if unset.
+DRAFTER_MODEL_ID = os.getenv("DRAFTER_MODEL_ID", os.getenv("OPENROUTER_MODEL_ID", "anthropic/claude-sonnet-5"))
+
+# Optional extended-thinking/reasoning controls, passed through to
+# OpenRouter's unified `reasoning` request field (see
+# https://openrouter.ai/docs/use-cases/reasoning-tokens). Unset by default -
+# drafting already tends to be slow (large CSV profiles, multi-table
+# prompts), so reasoning tokens are opt-in, not a silent default cost/latency
+# increase. Set at most one of these:
+#   DRAFTER_REASONING_EFFORT=high|medium|low   - qualitative effort level
+#   DRAFTER_REASONING_MAX_TOKENS=<int>          - explicit thinking-token budget
+DRAFTER_REASONING_EFFORT = os.getenv("DRAFTER_REASONING_EFFORT")
+DRAFTER_REASONING_MAX_TOKENS = os.getenv("DRAFTER_REASONING_MAX_TOKENS")
+
+
+class DraftCompletion(BaseModel):
+    text: str
+    model: str
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+
+
+class OpenRouterDraftClient:
+    def __init__(self, *, model_id: str | None = None, timeout: float = 300.0):
+        self.model_id = model_id or DRAFTER_MODEL_ID
+        self._client = httpx.Client(
+            base_url=OPENROUTER_BASE_URL,
+            headers={
+                "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+                "HTTP-Referer": os.getenv("FRONTEND_URL", "http://localhost:3000"),
+                "X-Title": "DataIO Metadata Drafter",
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+        )
+
+    def complete(self, *, system_prompt: str, user_prompt: str) -> DraftCompletion:
+        payload = {
+            "model": self.model_id,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "stream": False,
+        }
+        reasoning: dict = {}
+        if DRAFTER_REASONING_MAX_TOKENS:
+            reasoning["max_tokens"] = int(DRAFTER_REASONING_MAX_TOKENS)
+        elif DRAFTER_REASONING_EFFORT:
+            reasoning["effort"] = DRAFTER_REASONING_EFFORT
+        if reasoning:
+            payload["reasoning"] = reasoning
+
+        response = self._client.post("/chat/completions", json=payload)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # OpenRouter's actual rejection reason (e.g. "insufficient
+            # credits", a moderation block, a spend-limit message) lives in
+            # the response body - httpx's default exception message is just
+            # the status code, which isn't enough to tell those cases apart
+            # from the caller's error log alone.
+            raise httpx.HTTPStatusError(
+                f"{exc}. Response body: {response.text[:2000]}",
+                request=exc.request,
+                response=exc.response,
+            ) from exc
+        body = response.json()
+        choice = body["choices"][0]["message"]
+        usage = body.get("usage", {})
+        return DraftCompletion(
+            text=choice["content"],
+            model=body.get("model", self.model_id),
+            prompt_tokens=usage.get("prompt_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "OpenRouterDraftClient":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/src/dataio/api/services/openrouter_draft_client.py
+++ b/src/dataio/api/services/openrouter_draft_client.py
@@ -85,6 +85,12 @@ class OpenRouterDraftClient:
                 response=exc.response,
             ) from exc
         body = response.json()
+        if "choices" not in body:
+            # OpenRouter can return HTTP 200 with no "choices" key when the
+            # upstream provider fails after accepting the request (e.g. a
+            # provider-side error or moderation block) - the failure reason
+            # lives in body["error"], not in the HTTP status.
+            raise RuntimeError(f"OpenRouter returned no choices: {body.get('error', body)}")
         choice = body["choices"][0]["message"]
         usage = body.get("usage", {})
         return DraftCompletion(

--- a/src/dataio/api/services/openrouter_draft_client.py
+++ b/src/dataio/api/services/openrouter_draft_client.py
@@ -94,7 +94,13 @@ class OpenRouterDraftClient:
         choice = body["choices"][0]["message"]
         usage = body.get("usage", {})
         return DraftCompletion(
-            text=choice["content"],
+            # .get(...) or "" (not choice["content"]) - some providers omit
+            # "content" entirely or return it as null in edge-case
+            # responses; an empty string here fails parse_llm_output's
+            # delimiter check the same way any other malformed response
+            # does, routing into _complete_with_retry's existing retry
+            # path instead of an unhandled KeyError.
+            text=choice.get("content") or "",
             model=body.get("model", self.model_id),
             prompt_tokens=usage.get("prompt_tokens"),
             completion_tokens=usage.get("completion_tokens"),

--- a/src/dataio/api/services/reference_data.py
+++ b/src/dataio/api/services/reference_data.py
@@ -1,0 +1,33 @@
+"""Loads the curated, deterministic reference tables under
+`src/dataio/api/reference_data/` - the region-reorganization history
+(region_gap_detector.py) and the canonical cross-dataset enum registries
+(field_inference.lookup_canonical_enum_definitions). These are the
+deterministic replacement for the LLM drafter's "general/historical
+knowledge": static, curator-maintained facts looked up by exact match
+instead of recalled/generated per request.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+_REFERENCE_DATA_DIR = Path(__file__).resolve().parent.parent / "reference_data"
+
+
+@lru_cache(maxsize=1)
+def load_region_history() -> list[dict]:
+    """Returns the `events` list from region_history.yaml. Cached since
+    it's static reference data re-read on every table profiled otherwise.
+    """
+    with open(_REFERENCE_DATA_DIR / "region_history.yaml", encoding="utf-8") as f:
+        return yaml.safe_load(f)["events"]
+
+
+@lru_cache(maxsize=1)
+def load_canonical_enum_registry() -> list[dict]:
+    """Returns the `registries` list from canonical_enum_registry.yaml."""
+    with open(_REFERENCE_DATA_DIR / "canonical_enum_registry.yaml", encoding="utf-8") as f:
+        return yaml.safe_load(f)["registries"]

--- a/src/dataio/api/services/region_gap_detector.py
+++ b/src/dataio/api/services/region_gap_detector.py
@@ -1,0 +1,82 @@
+"""Deterministic gap-comment generation: cross-references a table's actual
+region x year coverage against the curated region_history.yaml reference
+table (known Indian state/UT reorganization events), and generates the
+same kind of `comments` entry the LLM drafter used to produce from general
+knowledge (e.g. "Telangana absent from 1997-2012 data... part of Andhra
+Pradesh until 2014") - but from a curated, curator-verified fact table
+cross-checked against the real data, not a hallucination risk.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from dataio.api.services.reference_data import load_region_history
+
+
+def detect_region_gaps(csv_path: str, region_column: str, date_column: str) -> list[str]:
+    """Reads csv_path directly - region x year presence isn't captured by
+    the lightweight per-column CsvProfile, only a real read gives the
+    joint distribution. For each region_history event whose `region`
+    actually appears in this table's data, adds an explanatory comment. If
+    the region appears *before* its documented effective date, that's
+    either a data-entry anomaly or evidence this dataset predates the
+    documented event differently than expected - flagged in the comment
+    text rather than silently accepted, since a curated fact contradicted
+    by the actual data is exactly the kind of thing a human should look at.
+
+    Matching is case-insensitive - real region-name columns are often
+    stored in a fixed case convention (e.g. all-caps, as in the actual
+    ARTPARK livestock census CSVs: "TELANGANA") that won't literally equal
+    region_history.yaml's human-readable casing ("Telangana").
+    """
+    df = pd.read_csv(csv_path, usecols=[region_column, date_column])
+    normalized_region = df[region_column].astype(str).str.casefold()
+    regions_present = set(normalized_region.dropna())
+    comments: list[str] = []
+
+    for event in load_region_history():
+        region = event["region"]
+        region_casefold = region.casefold()
+        if region_casefold not in regions_present:
+            continue
+        effective_year = int(event["effective_date"][:4])
+        years_for_region = pd.to_numeric(
+            df.loc[normalized_region == region_casefold, date_column], errors="coerce"
+        ).dropna()
+        earliest_year = int(years_for_region.min()) if not years_for_region.empty else None
+
+        if earliest_year is not None and earliest_year < effective_year:
+            comments.append(
+                f"[region history] '{region}' appears in this data as early as {earliest_year}, "
+                f"before its documented effective date of {event['effective_date']} "
+                f"({event['note']}) - worth checking this is expected for this dataset."
+            )
+        else:
+            comments.append(f"[region history] {event['note']}")
+
+    return comments
+
+
+def detect_region_gaps_for_table(csv_path: str, data_dictionary: dict[str, dict]) -> list[str]:
+    """Finds every regionName-typed column paired with a date-typed column
+    in this table's inferred data_dictionary (see field_inference) and
+    runs detect_region_gaps for each pair - the orchestration a caller
+    needs without having to know column names in advance. Returns
+    combined, de-duplicated comments in stable order.
+    """
+    date_types = {"date", "dateTime"}
+    region_columns = [name for name, f in data_dictionary.items() if f.get("type") == "regionName"]
+    date_columns = [name for name, f in data_dictionary.items() if f.get("type") in date_types]
+    if not region_columns or not date_columns:
+        return []
+
+    comments: list[str] = []
+    seen: set[str] = set()
+    for region_column in region_columns:
+        for date_column in date_columns:
+            for comment in detect_region_gaps(csv_path, region_column, date_column):
+                if comment not in seen:
+                    seen.add(comment)
+                    comments.append(comment)
+    return comments

--- a/src/dataio/api/services/region_gap_detector.py
+++ b/src/dataio/api/services/region_gap_detector.py
@@ -14,25 +14,27 @@ import pandas as pd
 from dataio.api.services.reference_data import load_region_history
 
 
-def detect_region_gaps(csv_path: str, region_column: str, date_column: str) -> list[str]:
-    """Reads csv_path directly - region x year presence isn't captured by
-    the lightweight per-column CsvProfile, only a real read gives the
-    joint distribution. For each region_history event whose `region`
-    actually appears in this table's data, adds an explanatory comment. If
-    the region appears *before* its documented effective date, that's
-    either a data-entry anomaly or evidence this dataset predates the
-    documented event differently than expected - flagged in the comment
-    text rather than silently accepted, since a curated fact contradicted
-    by the actual data is exactly the kind of thing a human should look at.
+def _region_gaps_from_frame(df: pd.DataFrame, region_column: str, date_column: str) -> list[str]:
+    """Core comparison logic, operating on an already-loaded DataFrame -
+    shared by detect_region_gaps (reads its own single-pair slice of the
+    CSV, for standalone callers) and detect_region_gaps_for_table (reads
+    the whole file once and reuses it across every region/date column
+    pair, rather than re-reading the same CSV from disk once per pair).
 
     Matching is case-insensitive - real region-name columns are often
     stored in a fixed case convention (e.g. all-caps, as in the actual
     ARTPARK livestock census CSVs: "TELANGANA") that won't literally equal
     region_history.yaml's human-readable casing ("Telangana").
     """
-    df = pd.read_csv(csv_path, usecols=[region_column, date_column])
     normalized_region = df[region_column].astype(str).str.casefold()
-    regions_present = set(normalized_region.dropna())
+    # Excludes genuinely-missing values from regions_present without
+    # dropping rows from normalized_region itself (which must stay the
+    # same length/index as df for the boolean mask below to align
+    # correctly) - otherwise a blank region value would astype(str) into
+    # the literal text "nan" and get treated as a real (bogus) region name,
+    # since a plain .dropna() afterward only removes actual nulls, not the
+    # string "nan" that .astype(str) already turned them into.
+    regions_present = set(normalized_region[df[region_column].notna()])
     comments: list[str] = []
 
     for event in load_region_history():
@@ -58,12 +60,32 @@ def detect_region_gaps(csv_path: str, region_column: str, date_column: str) -> l
     return comments
 
 
+def detect_region_gaps(csv_path: str, region_column: str, date_column: str) -> list[str]:
+    """Reads csv_path directly - region x year presence isn't captured by
+    the lightweight per-column CsvProfile, only a real read gives the
+    joint distribution. For each region_history event whose `region`
+    actually appears in this table's data, adds an explanatory comment. If
+    the region appears *before* its documented effective date, that's
+    either a data-entry anomaly or evidence this dataset predates the
+    documented event differently than expected - flagged in the comment
+    text rather than silently accepted, since a curated fact contradicted
+    by the actual data is exactly the kind of thing a human should look at.
+    """
+    df = pd.read_csv(csv_path, usecols=[region_column, date_column])
+    return _region_gaps_from_frame(df, region_column, date_column)
+
+
 def detect_region_gaps_for_table(csv_path: str, data_dictionary: dict[str, dict]) -> list[str]:
     """Finds every regionName-typed column paired with a date-typed column
     in this table's inferred data_dictionary (see field_inference) and
-    runs detect_region_gaps for each pair - the orchestration a caller
-    needs without having to know column names in advance. Returns
+    runs the region-gap comparison for each pair - the orchestration a
+    caller needs without having to know column names in advance. Returns
     combined, de-duplicated comments in stable order.
+
+    Reads csv_path once (covering every region/date column involved) and
+    reuses that single DataFrame across all pairs, rather than re-reading
+    the same file from disk once per pair - a table with e.g. 2 region
+    columns and 2 date columns would otherwise mean 4 separate full reads.
     """
     date_types = {"date", "dateTime"}
     region_columns = [name for name, f in data_dictionary.items() if f.get("type") == "regionName"]
@@ -71,11 +93,14 @@ def detect_region_gaps_for_table(csv_path: str, data_dictionary: dict[str, dict]
     if not region_columns or not date_columns:
         return []
 
+    needed_columns = sorted(set(region_columns) | set(date_columns))
+    df = pd.read_csv(csv_path, usecols=needed_columns)
+
     comments: list[str] = []
     seen: set[str] = set()
     for region_column in region_columns:
         for date_column in date_columns:
-            for comment in detect_region_gaps(csv_path, region_column, date_column):
+            for comment in _region_gaps_from_frame(df, region_column, date_column):
                 if comment not in seen:
                     seen.add(comment)
                     comments.append(comment)

--- a/src/dataio/api/services/web_admin_service.py
+++ b/src/dataio/api/services/web_admin_service.py
@@ -31,6 +31,7 @@ from dataio.api.auth.otp import create_otp, verify_otp
 from dataio.api.auth.security import enforce_rate_limit
 from dataio.api.services.base_service import BaseService
 from dataio.api.services.admin_dataset_service import AdminDatasetService
+from dataio.api.services.draft_review_service import DraftReviewService
 from dataio.api.services.email_service import EmailService
 from dataio.api.auth.permissions import is_admin
 from dataio.api.auth.security import record_auth_event
@@ -49,6 +50,7 @@ class WebAdminService(BaseService):
         super().__init__()
         self.email_service = EmailService()
         self.admin_dataset_service = AdminDatasetService()
+        self.draft_review_service = DraftReviewService()
         self.validation_service = DataIOValidationService(
             platform_manifest_checker=apply_platform_manifest_checks
         )
@@ -1519,9 +1521,11 @@ class WebAdminService(BaseService):
         self,
         admin_user: User,
         dataset_id: str | None = None,
+        *,
+        check_all: bool = False,
     ) -> dict:
         self._require_admin(admin_user)
-        return self.admin_dataset_service.check_dataset_documentation_sync(dataset_id)
+        return self.admin_dataset_service.check_dataset_documentation_sync(dataset_id, check_all=check_all)
 
     def sync_dataset_documentation(
         self,
@@ -1584,6 +1588,66 @@ class WebAdminService(BaseService):
             manifest_file,
             admin_user.email,
         )
+
+    def generate_manifest_draft(
+        self,
+        admin_user: User,
+        csv_files,
+        category_id: str,
+        collection_id: str,
+        data_owner_name: str,
+        dataset_id: Optional[str] = None,
+        digitization_log_file=None,
+    ) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.generate_draft_from_upload(
+            csv_files=csv_files,
+            category_id=category_id,
+            collection_id=collection_id,
+            data_owner_name=data_owner_name,
+            created_by=admin_user.email,
+            dataset_id=dataset_id,
+            digitization_log_file=digitization_log_file,
+        )
+
+    def list_manifest_drafts(
+        self,
+        admin_user: User,
+        status: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.list_drafts(status=status, dataset_id=dataset_id, limit=limit, offset=offset)
+
+    def get_manifest_draft(self, admin_user: User, draft_id: str) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.get_draft(draft_id)
+
+    def delete_manifest_draft(self, admin_user: User, draft_id: str) -> None:
+        self._require_admin(admin_user)
+        self.draft_review_service.delete_draft(draft_id)
+
+    def revalidate_manifest_draft(self, admin_user: User, draft_id: str) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.revalidate_draft(draft_id)
+
+    def approve_manifest_draft(self, admin_user: User, draft_id: str) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.approve_draft(draft_id, admin_user.email)
+
+    def reject_manifest_draft(self, admin_user: User, draft_id: str, reason: Optional[str] = None) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.reject_draft(draft_id, admin_user.email, reason=reason)
+
+    def flag_manifest_draft_field(self, admin_user: User, draft_id: str, field_path: str, note: str) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.flag_field(draft_id, field_path, note, admin_user.email)
+
+    def regenerate_manifest_draft(self, admin_user: User, draft_id: str) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.regenerate_draft(draft_id, admin_user.email)
 
     def validate_dataset(
         self,

--- a/src/dataio/api/services/web_admin_service.py
+++ b/src/dataio/api/services/web_admin_service.py
@@ -7,7 +7,9 @@ permissions, manifests, and validation through the web interface.
 
 import logging
 import json
+import os
 import re
+import tempfile
 from io import BytesIO
 from pathlib import Path
 from typing import List, Optional
@@ -1429,6 +1431,57 @@ class WebAdminService(BaseService):
             "manifest_uploaded": True,
         }
 
+    def import_dataset_from_draft(
+        self,
+        admin_user: User,
+        draft_id: str,
+        access_level: str,
+        bucket_type: VersionType = VersionType.STANDARDISED,
+    ) -> dict:
+        """Skips the manual "download draft_yaml + info.yml, re-upload
+        through the Import Dataset Package tool" handoff (see
+        DatasetManifestDraft's docstring) by driving import_dataset_package
+        directly from an approved draft's own already-stored fields - same
+        validation, same S3/Postgres writes as the Import tab, just without
+        a curator round-tripping files through their own machine first.
+        """
+        self._require_admin(admin_user)
+        draft = self.draft_review_service._get_draft_or_404(draft_id)
+        if draft.status.value != "approved":
+            raise HTTPException(status_code=400, detail="Approve this draft before uploading it.")
+
+        info_yaml = self.draft_review_service.generate_info_yaml(draft_id, access_level)["info_yaml"]
+
+        # Local import matches regenerate_draft's own convention
+        # (draft_review_service.py) for reaching into draft_service.py.
+        from dataio.api.services.draft_service import decode_csv_paths
+
+        table_names = list((draft.draft_json or {}).get("tables", {}).keys())
+        csv_paths_by_table = decode_csv_paths(draft.source_csv_path, table_names)
+
+        csv_files = []
+        for table_name, path in csv_paths_by_table.items():
+            try:
+                with open(path, "rb") as f:
+                    csv_files.append(UploadFile(filename=f"{table_name}.csv", file=BytesIO(f.read())))
+            except OSError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Could not read stored CSV for table '{table_name}': {exc}",
+                ) from exc
+
+        info_file = UploadFile(filename="info.yml", file=BytesIO(info_yaml.encode("utf-8")))
+        metadata_file = UploadFile(filename="metadata.yaml", file=BytesIO(draft.draft_yaml.encode("utf-8")))
+
+        return self.import_dataset_package(
+            admin_user,
+            info_file,
+            metadata_file,
+            csv_files,
+            dataset_override={"existing_dataset_id": draft.dataset_id},
+            bucket_type=bucket_type,
+        )
+
     def initiate_dataset_deletion(self, admin_user: User, dataset_id: str) -> dict:
         self._require_admin(admin_user)
         if not database.check_if_dataset_exists(dataset_id):
@@ -1634,6 +1687,28 @@ class WebAdminService(BaseService):
     def classify_columns(self, admin_user: User, column_names: list) -> dict:
         self._require_admin(admin_user)
         return self.draft_review_service.classify_columns(column_names=column_names)
+
+    def infer_dataset_coverage(self, admin_user: User, csv_files: List) -> dict:
+        """Writes each uploaded CSV to a throwaway temp file (this runs
+        before any draft exists - there's nothing to persist to, unlike
+        draft_upload_storage.save_upload) just long enough to profile it,
+        then cleans up regardless of outcome.
+        """
+        self._require_admin(admin_user)
+        temp_paths: List[str] = []
+        try:
+            for file in csv_files:
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
+                    file.file.seek(0)
+                    tmp.write(file.file.read())
+                    temp_paths.append(tmp.name)
+            return self.draft_review_service.infer_dataset_coverage(temp_paths)
+        finally:
+            for path in temp_paths:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
 
     def list_manifest_drafts(
         self,

--- a/src/dataio/api/services/web_admin_service.py
+++ b/src/dataio/api/services/web_admin_service.py
@@ -1680,6 +1680,12 @@ class WebAdminService(BaseService):
         self._require_admin(admin_user)
         return self.draft_review_service.regenerate_draft(draft_id, admin_user.email)
 
+    def generate_manifest_draft_info_yaml(
+        self, admin_user: User, draft_id: str, access_level: str
+    ) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.generate_info_yaml(draft_id, access_level)
+
     def validate_dataset(
         self,
         admin_user: User,

--- a/src/dataio/api/services/web_admin_service.py
+++ b/src/dataio/api/services/web_admin_service.py
@@ -1610,6 +1610,31 @@ class WebAdminService(BaseService):
             digitization_log_file=digitization_log_file,
         )
 
+    def generate_deterministic_manifest_draft(
+        self,
+        admin_user: User,
+        csv_files,
+        category_id: str,
+        collection_id: str,
+        data_owner_name: str,
+        curator_input: dict,
+        dataset_id: Optional[str] = None,
+    ) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.generate_deterministic_draft_from_upload(
+            csv_files=csv_files,
+            category_id=category_id,
+            collection_id=collection_id,
+            data_owner_name=data_owner_name,
+            created_by=admin_user.email,
+            curator_input=curator_input,
+            dataset_id=dataset_id,
+        )
+
+    def classify_columns(self, admin_user: User, column_names: list) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.classify_columns(column_names=column_names)
+
     def list_manifest_drafts(
         self,
         admin_user: User,
@@ -1644,6 +1669,12 @@ class WebAdminService(BaseService):
     def flag_manifest_draft_field(self, admin_user: User, draft_id: str, field_path: str, note: str) -> dict:
         self._require_admin(admin_user)
         return self.draft_review_service.flag_field(draft_id, field_path, note, admin_user.email)
+
+    def update_manifest_draft_content(
+        self, admin_user: User, draft_id: str, draft_yaml: str
+    ) -> dict:
+        self._require_admin(admin_user)
+        return self.draft_review_service.update_draft_content(draft_id, draft_yaml)
 
     def regenerate_manifest_draft(self, admin_user: User, draft_id: str) -> dict:
         self._require_admin(admin_user)

--- a/src/dataio/api/tests/test_admin_manifest_service.py
+++ b/src/dataio/api/tests/test_admin_manifest_service.py
@@ -200,6 +200,59 @@ def test_check_dataset_documentation_sync_requires_dataset_id():
         raise AssertionError("Expected HTTPException to be raised")
 
 
+def test_check_dataset_documentation_sync_check_all_checks_every_dataset(monkeypatch):
+    """check_all=True is the opt-in for summary use (e.g. the admin overview's
+    outdated-docs count) - unlike the bare no-args call above, it must not
+    raise, and it must check every dataset in the table, not just one.
+    """
+    service = object.__new__(AdminDatasetService)
+    service.logger = logging.getLogger(__name__)
+    service.filestore_service = SimpleNamespace(bucket="test-bucket")
+
+    class RowsResult:
+        def all(self):
+            return [("CS0001DS0001",), ("CS0002DS0002",)]
+
+    class SessionStub:
+        def execute(self, query):
+            return RowsResult()
+
+        def rollback(self):
+            return None
+
+        def close(self):
+            return None
+
+    service.db_session_factory = lambda: SessionStub()
+
+    statuses_by_dataset = {
+        "CS0001DS0001": {
+            "needs_update": True,
+            "changed_fields": ["manifest"],
+            "has_remote_documentation": True,
+            "manifest_updated_at": None,
+            "documentation_synced_at": None,
+        },
+        "CS0002DS0002": {
+            "needs_update": False,
+            "changed_fields": [],
+            "has_remote_documentation": True,
+            "manifest_updated_at": None,
+            "documentation_synced_at": None,
+        },
+    }
+    monkeypatch.setattr(
+        "dataio.api.services.admin_dataset_service.get_dataset_documentation_status",
+        lambda session, bucket, dataset_id: statuses_by_dataset[dataset_id],
+    )
+
+    result = service.check_dataset_documentation_sync(check_all=True)
+
+    assert result["total"] == 2
+    assert result["outdated"] == 1
+    assert {row["ds_id"] for row in result["datasets"]} == {"CS0001DS0001", "CS0002DS0002"}
+
+
 def test_sync_dataset_documentation_requires_dataset_id():
     service = object.__new__(AdminDatasetService)
     service.logger = logging.getLogger(__name__)

--- a/src/dataio/api/tests/test_csv_profiler.py
+++ b/src/dataio/api/tests/test_csv_profiler.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dataio.api.services.csv_profiler import (
+    detect_missing_source_concepts,
+    profile_csv,
+    read_full_csv_text,
+)
+
+CSV_WITH_SOURCE_COLUMNS = """state,year,value,sourceTableID,sourcePage,sourceDocument
+Karnataka,2019,120,Table 4.2,p. 37,https://example.gov/report.pdf
+Kerala,2019,,Table 4.2,p. 37,https://example.gov/report.pdf
+Karnataka,2020,130,Table 4.2,p. 37,https://example.gov/report.pdf
+"""
+
+CSV_WITHOUT_SOURCE_COLUMNS = """state,year,value
+Karnataka,2019,120
+Kerala,2019,95
+"""
+
+
+def test_profile_csv_computes_dtype_null_and_cardinality(tmp_path: Path):
+    csv_path = tmp_path / "with_source.csv"
+    csv_path.write_text(CSV_WITH_SOURCE_COLUMNS, encoding="utf-8")
+
+    profile = profile_csv(csv_path)
+
+    assert profile.row_count == 3
+    value_col = next(c for c in profile.columns if c.name == "value")
+    assert value_col.null_count == 1
+    assert value_col.null_fraction == 1 / 3
+    assert value_col.min_value == "120.0"
+    assert value_col.max_value == "130.0"
+
+    state_col = next(c for c in profile.columns if c.name == "state")
+    assert state_col.distinct_count == 2
+
+
+def test_profile_csv_reports_no_missing_source_columns_when_present(tmp_path: Path):
+    csv_path = tmp_path / "with_source.csv"
+    csv_path.write_text(CSV_WITH_SOURCE_COLUMNS, encoding="utf-8")
+
+    profile = profile_csv(csv_path)
+
+    assert profile.missing_source_columns == []
+
+
+def test_profile_csv_flags_missing_source_columns(tmp_path: Path):
+    csv_path = tmp_path / "without_source.csv"
+    csv_path.write_text(CSV_WITHOUT_SOURCE_COLUMNS, encoding="utf-8")
+
+    profile = profile_csv(csv_path)
+
+    assert set(profile.missing_source_columns) == {"sourceDocument", "sourceTableID", "sourcePage"}
+
+
+def test_detect_missing_source_concepts_recognizes_alternate_naming():
+    # Different naming per dataset (not the exact literal "sourceTableID"/
+    # "sourcePage"/"sourceDocument") must still be recognized.
+    columns = ["state", "year", "value", "Source_Table_No", "PageNumber", "citation_url"]
+
+    assert detect_missing_source_concepts(columns) == []
+
+
+def test_detect_missing_source_concepts_reports_only_genuinely_absent_ones():
+    # This dataset (e.g. Excel-derived, single workbook) has a document
+    # reference but no per-row table/page concept - only those two should
+    # be reported missing, not sourceDocument.
+    columns = ["state", "year", "value", "source_reference"]
+
+    assert detect_missing_source_concepts(columns) == ["sourceTableID", "sourcePage"]
+
+
+def test_detect_missing_source_concepts_does_not_let_source_prefix_satisfy_other_concepts():
+    # A column literally named "sourceTableID" contains the substring
+    # "source" - that must not be enough to also satisfy the sourceDocument
+    # concept, which needs its own distinguishing keyword (document/
+    # citation/reference/etc.), not just the shared "source" prefix.
+    columns = ["state", "sourceTableID"]
+
+    assert set(detect_missing_source_concepts(columns)) == {"sourceDocument", "sourcePage"}
+
+
+def test_profile_csv_bounds_sample_rows(tmp_path: Path):
+    csv_path = tmp_path / "with_source.csv"
+    csv_path.write_text(CSV_WITH_SOURCE_COLUMNS, encoding="utf-8")
+
+    profile = profile_csv(csv_path, sample_rows=2)
+
+    # header + 2 data rows
+    assert profile.sample_rows_csv.strip().count("\n") == 2
+
+
+def test_read_full_csv_text_roundtrips(tmp_path: Path):
+    csv_path = tmp_path / "without_source.csv"
+    csv_path.write_text(CSV_WITHOUT_SOURCE_COLUMNS, encoding="utf-8")
+
+    assert read_full_csv_text(csv_path) == CSV_WITHOUT_SOURCE_COLUMNS
+
+
+def test_profile_csv_includes_complete_distinct_values_for_low_cardinality_columns(tmp_path: Path):
+    # A rare value ("breeding & work") that a top-10 sample could easily miss
+    # in a bigger real dataset - all_distinct_values must still surface it.
+    csv_text = "utility\n" + "\n".join(["breeding only"] * 50 + ["work only"] * 50 + ["breeding & work"])
+    csv_path = tmp_path / "utility.csv"
+    csv_path.write_text(csv_text, encoding="utf-8")
+
+    profile = profile_csv(csv_path)
+    utility_col = next(c for c in profile.columns if c.name == "utility")
+
+    assert utility_col.all_distinct_values == ["breeding & work", "breeding only", "work only"]
+
+
+def test_profile_csv_omits_all_distinct_values_above_cardinality_threshold(tmp_path: Path, monkeypatch):
+    import dataio.api.services.csv_profiler as profiler_module
+
+    monkeypatch.setattr(profiler_module, "ENUM_CANDIDATE_MAX_CARDINALITY", 2)
+    csv_path = tmp_path / "with_source.csv"
+    csv_path.write_text(CSV_WITH_SOURCE_COLUMNS, encoding="utf-8")
+
+    profile = profile_csv(csv_path)
+    year_col = next(c for c in profile.columns if c.name == "year")
+
+    # 2 distinct years (2019, 2020) is within the (monkeypatched) threshold of 2
+    assert year_col.all_distinct_values == ["2019", "2020"]
+
+    state_col = next(c for c in profile.columns if c.name == "state")
+    # 2 distinct states is also within threshold - shrink further to prove the None branch
+    monkeypatch.setattr(profiler_module, "ENUM_CANDIDATE_MAX_CARDINALITY", 1)
+    profile = profile_csv(csv_path)
+    state_col = next(c for c in profile.columns if c.name == "state")
+    assert state_col.all_distinct_values is None

--- a/src/dataio/api/tests/test_deterministic_draft_service.py
+++ b/src/dataio/api/tests/test_deterministic_draft_service.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from dataio.api.services import deterministic_draft_service, draft_service
+from dataio.api.services.deterministic_draft_service import CuratorMetadataInput, TagsInput
+from dataio.validate.reports.models import ValidationResult
+
+FAKE_COLLECTION = SimpleNamespace(
+    collection_id="CS0007", collection_name="Livestock Census (by DAHD)",
+    category_id="CS", category_name="Census and Surveys",
+)
+
+CSV_TEXT = """state.ID,state.lgd_code,state.name,year,species,count
+state_KA,29,Karnataka,2019,cattle,120
+state_TG,36,Telangana,2019,buffalo,80
+"""
+
+
+def _curator_input(**overrides):
+    defaults = dict(
+        datasetDescription="State-level livestock counts.",
+        source=["16th Livestock Census"],
+        references=["https://example.gov/report.pdf"],
+        tags=TagsInput(concept=["livestock"], epiType=["population"]),
+        spatialCoverage="India",
+        spatialResolution="state",
+        temporalCoverage="2019",
+        temporalResolution="annual",
+        updateFrequency="Annual",
+        comments=["Curator-supplied fact."],
+        joinKeyColumns=[],
+        tableDescriptions={"table": "State-level livestock counts for this table."},
+        # state.ID/state.lgd_code/state.name are auto-filled by
+        # infer_fixed_column_description - only year/species/count need a
+        # curator-supplied description for the CSV_TEXT columns.
+        columnDescriptions={
+            "table": {
+                "year": "Census reference year.",
+                "species": "Livestock species.",
+                "count": "Number of animals counted.",
+            },
+        },
+    )
+    defaults.update(overrides)
+    return CuratorMetadataInput(**defaults)
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(draft_service, "get_collection_by_identifier", lambda collection_id: FAKE_COLLECTION)
+    monkeypatch.setattr(
+        draft_service, "_validate_manifest",
+        lambda manifest_dict, csv_paths_by_table: ValidationResult(dataset_kind="tabular"),
+    )
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        lambda category_id: "CSRDS0099",
+    )
+
+
+def _fake_create_manifest_draft(recorded):
+    def create(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(
+            draft_id="11111111-1111-1111-1111-111111111111",
+            status=SimpleNamespace(value="pending"),
+            draft_yaml=kwargs["draft_yaml"],
+            draft_json=kwargs["draft_json"],
+            flagged_fields=kwargs["flagged_fields"],
+        )
+    return create
+
+
+def test_generate_deterministic_draft_infers_types_and_persists_no_llm_model_id(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "consolidated-livestock-census.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    recorded: dict = {}
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft(recorded))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD",
+        curator_input=_curator_input(
+            tableDescriptions={"consolidated-livestock-census": "State-level livestock counts."},
+            columnDescriptions={
+                "consolidated-livestock-census": {
+                    "year": "Census reference year.",
+                    "species": "Livestock species.",
+                    "count": "Number of animals counted.",
+                },
+            },
+        ),
+    )
+
+    assert result.status == "pending"
+    assert result.validation_status == "pass"
+    assert recorded["llm_model_id"] is None  # deterministic, not LLM-authored
+    assert result.draft_json["datasetID"] == "CS0007DS0999"
+    assert result.draft_json["datasetOwner"] == "DAHD"
+    assert result.draft_json["lastUpdated"] == date.today().isoformat()
+
+    table = result.draft_json["tables"]["consolidated-livestock-census"]
+    assert table["description"] == "State-level livestock counts."
+    data_dictionary = table["data_dictionary"]
+    assert data_dictionary["state.ID"]["type"] == "regionID"
+    assert data_dictionary["state.name"]["type"] == "regionName"
+    assert data_dictionary["state.lgd_code"]["type"] == "int"
+    assert data_dictionary["year"]["type"] == "date"
+    assert data_dictionary["year"]["format"] == "%Y"
+    assert data_dictionary["species"]["type"] == "enum"
+
+    # Fixed-pattern columns get an auto-filled description; the curator was
+    # never asked for one.
+    assert data_dictionary["state.ID"]["description"].startswith("LGD-based region identifier")
+    assert data_dictionary["species"]["description"] == "Livestock species."
+
+
+def test_generate_deterministic_draft_uses_curator_supplied_narrative_fields(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(datasetDescription="Custom description."),
+    )
+
+    assert result.draft_json["datasetDescription"] == "Custom description."
+    assert result.draft_json["source"] == ["16th Livestock Census"]
+    assert result.draft_json["tags"] == {"concept": ["livestock"], "epiType": ["population"]}
+    assert "Curator-supplied fact." in result.draft_json["comments"]
+
+
+def test_generate_deterministic_draft_auto_applies_region_lgd_join_keys_when_curator_leaves_them_unset(
+    tmp_path: Path, monkeypatch
+):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(joinKeyColumns=[]),
+    )
+
+    table = result.draft_json["tables"]["table"]
+    # state.ID must never appear in joinKeys without its lgd_code sibling.
+    assert "state.lgd_code" in table["joinKeys"]
+    assert "state.ID" in table["joinKeys"]
+    assert table["data_dictionary"]["state.ID"]["isJoinKey"] is True
+    assert table["data_dictionary"]["state.ID"]["joinKeyType"] == "compositeComponent"
+    assert table["data_dictionary"]["year"]["joinKeyType"] == "temporal"
+
+
+def test_generate_deterministic_draft_respects_curator_confirmed_join_keys(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(joinKeyColumns=["year"]),
+    )
+
+    assert result.draft_json["joinKeys"] == ["year"]
+    table = result.draft_json["tables"]["table"]
+    assert table["joinKeys"] == ["year"]
+    assert "isJoinKey" not in table["data_dictionary"]["state.ID"]
+
+
+def test_generate_deterministic_draft_includes_canonical_species_registry(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(),
+    )
+
+    assert "canonicalSpecies" in result.draft_json["canonicalEnumDefinitions"]
+    assert "canonicalBreed" not in result.draft_json["canonicalEnumDefinitions"]
+
+
+def test_generate_deterministic_draft_cross_links_enum_values_to_canonical_registry(
+    tmp_path: Path, monkeypatch
+):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")  # species column has values cattle/buffalo
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}),
+    )
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD", curator_input=_curator_input(),
+    )
+
+    species_values = result.draft_json["enumDefinitions"]["speciesEnum"]["values"]
+    assert species_values["cattle"]["canonical"] == "cattle"
+    assert species_values["cattle"]["canonicalRollup"] == "cattle"
+    assert species_values["buffalo"]["canonical"] == "buffalo"
+
+
+def test_generate_deterministic_draft_broadens_join_keys_to_enum_dimension_columns(
+    tmp_path: Path, monkeypatch
+):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}),
+    )
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+        curator_input=_curator_input(joinKeyColumns=[]),
+    )
+
+    table = result.draft_json["tables"]["table"]
+    assert "species" in table["joinKeys"]
+    assert table["data_dictionary"]["species"]["isJoinKey"] is True
+    assert table["data_dictionary"]["species"]["joinKeyType"] == "compositeComponent"
+
+
+def test_generate_deterministic_draft_flags_missing_source_columns(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")  # no sourceDocument/sourceTableID/sourcePage columns
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(),
+    )
+
+    fields_flagged = {f["field"] for f in result.flagged_fields}
+    assert {"sourceDocument", "sourceTableID", "sourcePage"} <= fields_flagged
+
+
+def test_generate_deterministic_draft_detects_telangana_region_gap(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")  # includes a 2019 Telangana row - matches real history
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(),
+    )
+
+    assert any("Telangana" in c for c in result.draft_json["comments"])
+
+
+def test_generate_deterministic_draft_requires_dataset_title_for_multiple_csvs(tmp_path: Path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    csv_path_1 = tmp_path / "table-one.csv"
+    csv_path_1.write_text(CSV_TEXT, encoding="utf-8")
+    csv_path_2 = tmp_path / "table-two.csv"
+    csv_path_2.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_path_1), str(csv_path_2)], category_id="CS", collection_id="CS0007",
+            created_by="engineer@artpark.in", data_owner_name="DAHD",
+            curator_input=_curator_input(
+                tableDescriptions={"table-one": "Table one.", "table-two": "Table two."},
+                columnDescriptions={
+                    "table-one": {"year": "y", "species": "s", "count": "c"},
+                    "table-two": {"year": "y", "species": "s", "count": "c"},
+                },
+            ),
+        )
+    assert exc_info.value.status_code == 400
+    assert "title" in exc_info.value.detail.lower()
+
+
+def test_generate_deterministic_draft_uses_curator_supplied_title_for_multiple_csvs(
+    tmp_path: Path, monkeypatch
+):
+    csv_path_1 = tmp_path / "table-one.csv"
+    csv_path_1.write_text(CSV_TEXT, encoding="utf-8")
+    csv_path_2 = tmp_path / "table-two.csv"
+    csv_path_2.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}),
+    )
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path_1), str(csv_path_2)], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+        curator_input=_curator_input(
+            datasetTitle="my-combined-dataset",
+            tableDescriptions={"table-one": "Table one.", "table-two": "Table two."},
+            columnDescriptions={
+                "table-one": {"year": "y", "species": "s", "count": "c"},
+                "table-two": {"year": "y", "species": "s", "count": "c"},
+            },
+        ),
+    )
+
+    assert result.draft_json["datasetTitle"] == "my-combined-dataset"
+
+
+def test_generate_deterministic_draft_ignores_dataset_title_for_a_single_csv(tmp_path: Path, monkeypatch):
+    # A single-CSV dataset is always named after that CSV's own filename,
+    # matching the established hand-authored convention - a curator-supplied
+    # datasetTitle only takes effect with 2+ CSVs.
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(datasetTitle="ignored-title"),
+    )
+
+    assert result.draft_json["datasetTitle"] == "table"
+
+
+def test_generate_deterministic_draft_disambiguates_colliding_enum_refs_across_tables(
+    tmp_path: Path, monkeypatch
+):
+    # Regression: two tables each have their own "indicator" column with
+    # completely disjoint values - _enum_ref_name gives both the same
+    # "indicatorEnum" ref since it only looks at the bare column name.
+    # Blindly merging must not let table two's values silently overwrite
+    # table one's in the final enumDefinitions (which would make every row
+    # of table one fail validation for a value that is actually valid).
+    columns = "state.ID,state.lgd_code,state.name,year,indicator,count"
+    csv_text_a = f"{columns}\nstate_KA,29,Karnataka,2019,alpha,1\n"
+    csv_text_b = f"{columns}\nstate_KA,29,Karnataka,2019,gamma,1\n"
+    csv_path_a = tmp_path / "table-a.csv"
+    csv_path_a.write_text(csv_text_a, encoding="utf-8")
+    csv_path_b = tmp_path / "table-b.csv"
+    csv_path_b.write_text(csv_text_b, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}),
+    )
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path_a), str(csv_path_b)], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+        curator_input=_curator_input(
+            datasetTitle="two-table-dataset",
+            tableDescriptions={"table-a": "Table A.", "table-b": "Table B."},
+            columnDescriptions={
+                "table-a": {"year": "y", "indicator": "i", "count": "c"},
+                "table-b": {"year": "y", "indicator": "i", "count": "c"},
+            },
+        ),
+    )
+
+    data_dictionary_a = result.draft_json["tables"]["table-a"]["data_dictionary"]
+    data_dictionary_b = result.draft_json["tables"]["table-b"]["data_dictionary"]
+    assert data_dictionary_a["indicator"]["enumRef"] == "indicatorEnum"
+    assert data_dictionary_b["indicator"]["enumRef"] == "indicatorEnum2"
+
+    enum_definitions = result.draft_json["enumDefinitions"]
+    assert set(enum_definitions["indicatorEnum"]["values"]) == {"alpha"}
+    assert set(enum_definitions["indicatorEnum2"]["values"]) == {"gamma"}
+
+
+def test_generate_deterministic_draft_merges_identical_enums_across_tables_under_one_name(
+    tmp_path: Path, monkeypatch
+):
+    # Two tables sharing a column with the *same* observed values (a common,
+    # legitimate case - e.g. shared locality categories) must still merge
+    # under the one ref, not get needlessly disambiguated.
+    columns = "state.ID,state.lgd_code,state.name,year,indicator,count"
+    csv_text = f"{columns}\nstate_KA,29,Karnataka,2019,alpha,1\n"
+    csv_path_a = tmp_path / "table-a.csv"
+    csv_path_a.write_text(csv_text, encoding="utf-8")
+    csv_path_b = tmp_path / "table-b.csv"
+    csv_path_b.write_text(csv_text, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}),
+    )
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path_a), str(csv_path_b)], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+        curator_input=_curator_input(
+            datasetTitle="two-table-dataset",
+            tableDescriptions={"table-a": "Table A.", "table-b": "Table B."},
+            columnDescriptions={
+                "table-a": {"year": "y", "indicator": "i", "count": "c"},
+                "table-b": {"year": "y", "indicator": "i", "count": "c"},
+            },
+        ),
+    )
+
+    data_dictionary_a = result.draft_json["tables"]["table-a"]["data_dictionary"]
+    data_dictionary_b = result.draft_json["tables"]["table-b"]["data_dictionary"]
+    assert data_dictionary_a["indicator"]["enumRef"] == "indicatorEnum"
+    assert data_dictionary_b["indicator"]["enumRef"] == "indicatorEnum"
+    assert "indicatorEnum2" not in result.draft_json["enumDefinitions"]
+
+
+def test_generate_deterministic_draft_raises_when_no_csv_paths(monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+            data_owner_name="DAHD", curator_input=_curator_input(),
+        )
+
+
+def test_generate_deterministic_draft_raises_when_collection_does_not_exist(tmp_path: Path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "get_collection_by_identifier", lambda collection_id: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_path)], category_id="CS", collection_id="CS9999", created_by="engineer@artpark.in",
+            data_owner_name="DAHD", curator_input=_curator_input(),
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_generate_deterministic_draft_raises_when_table_description_missing(tmp_path: Path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+            data_owner_name="DAHD", curator_input=_curator_input(tableDescriptions={}),
+        )
+    assert exc_info.value.status_code == 400
+    assert "table" in exc_info.value.detail
+
+
+def test_generate_deterministic_draft_raises_when_table_description_is_blank(tmp_path: Path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+            data_owner_name="DAHD", curator_input=_curator_input(tableDescriptions={"table": "   "}),
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_generate_deterministic_draft_raises_when_column_description_missing(tmp_path: Path, monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+            data_owner_name="DAHD",
+            curator_input=_curator_input(columnDescriptions={"table": {"year": "Census reference year."}}),
+        )
+    assert exc_info.value.status_code == 400
+    assert "table.species" in exc_info.value.detail
+    assert "table.count" in exc_info.value.detail
+    # state.ID/state.lgd_code/state.name are fixed-pattern - never required.
+    assert "state.ID" not in exc_info.value.detail
+
+
+def test_generate_deterministic_draft_never_requires_a_fixed_pattern_column(tmp_path: Path, monkeypatch):
+    """Region-identifier and source/provenance columns are auto-filled by
+    infer_fixed_column_description regardless of what (if anything) the
+    curator supplied for them - generation must not block on these even
+    when columnDescriptions is completely empty for the table.
+    """
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD",
+        curator_input=_curator_input(
+            columnDescriptions={
+                "table": {
+                    "year": "Census reference year.",
+                    "species": "Livestock species.",
+                    "count": "Number of animals counted.",
+                    # state.ID/state.name/state.lgd_code deliberately omitted.
+                },
+            },
+        ),
+    )
+
+    data_dictionary = result.draft_json["tables"]["table"]["data_dictionary"]
+    assert data_dictionary["state.ID"]["description"].startswith("LGD-based region identifier")
+    assert data_dictionary["state.name"]["description"] == "State or union territory name in title case as per LGD."
+    assert data_dictionary["state.lgd_code"]["description"] == (
+        "Standard numeric Local Government Directory (LGD) code for the state or union territory."
+    )

--- a/src/dataio/api/tests/test_deterministic_draft_service.py
+++ b/src/dataio/api/tests/test_deterministic_draft_service.py
@@ -189,6 +189,30 @@ def test_generate_deterministic_draft_respects_curator_confirmed_join_keys(tmp_p
     assert "isJoinKey" not in table["data_dictionary"]["state.ID"]
 
 
+def test_generate_deterministic_draft_drops_nonexistent_curator_join_key_from_dataset_level_list(
+    tmp_path: Path, monkeypatch
+):
+    """A curator-supplied joinKeyColumns override that includes a column
+    not present in any table (a typo, or a list pasted from a different
+    dataset) must not leak into the dataset-level joinKeys - only columns
+    infer_table_structure actually validated against a real table's
+    data_dictionary should appear there.
+    """
+    csv_path = tmp_path / "table.csv"
+    csv_path.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", _fake_create_manifest_draft({}))
+
+    result = deterministic_draft_service.generate_deterministic_draft(
+        csv_paths=[str(csv_path)], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", curator_input=_curator_input(joinKeyColumns=["year", "no_such_column"]),
+    )
+
+    assert result.draft_json["joinKeys"] == ["year"]
+    assert "no_such_column" not in result.draft_json["joinKeys"]
+
+
 def test_generate_deterministic_draft_includes_canonical_species_registry(tmp_path: Path, monkeypatch):
     csv_path = tmp_path / "table.csv"
     csv_path.write_text(CSV_TEXT, encoding="utf-8")
@@ -465,6 +489,34 @@ def test_generate_deterministic_draft_raises_when_collection_does_not_exist(tmp_
             data_owner_name="DAHD", curator_input=_curator_input(),
         )
     assert exc_info.value.status_code == 400
+
+
+def test_generate_deterministic_draft_rejects_duplicate_csv_filename_stems(tmp_path: Path, monkeypatch):
+    """Two uploaded CSVs that share a filename stem (e.g. from different
+    folders) must be rejected up front, not silently collapsed into one
+    table by the csv_paths_by_table dict build.
+    """
+    import pytest
+    from fastapi import HTTPException
+
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    csv_a = dir_a / "table.csv"
+    csv_a.write_text(CSV_TEXT, encoding="utf-8")
+    csv_b = dir_b / "table.csv"
+    csv_b.write_text(CSV_TEXT, encoding="utf-8")
+
+    _patch_common(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        deterministic_draft_service.generate_deterministic_draft(
+            csv_paths=[str(csv_a), str(csv_b)], category_id="CS", collection_id="CS0007",
+            created_by="engineer@artpark.in", data_owner_name="DAHD", curator_input=_curator_input(),
+        )
+    assert exc_info.value.status_code == 400
+    assert "table" in exc_info.value.detail
 
 
 def test_generate_deterministic_draft_raises_when_table_description_missing(tmp_path: Path, monkeypatch):

--- a/src/dataio/api/tests/test_digitization_log.py
+++ b/src/dataio/api/tests/test_digitization_log.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dataio.api.services.digitization_log import DigitizationLog, load_digitization_log
+
+FIXTURE_YAML = """
+schemaVersion: "1.0"
+preparedBy: "engineer@artpark.in"
+preparedAt: "2026-07-21"
+sourceDocuments:
+  - sourceTableID: "Table 4.2"
+    sourcePage: "p. 37"
+    sourceDocument: "https://example.gov/report.pdf"
+observations:
+  - id: "obs-1"
+    description: "Telangana absent before 2014 - didn't exist as a separate state yet."
+    resolution: "expected"
+  - id: "obs-2"
+    description: "A handful of 2021 rows have negative values, cause unclear."
+    resolution: "needs_investigation"
+normalizationSteps:
+  - id: "norm-1"
+    description: "Renamed 'Dist_Name' to 'district_name'."
+    field: "district_name"
+    changeType: "rename"
+notes: "free text"
+"""
+
+
+def test_load_digitization_log_returns_none_for_missing_path(tmp_path: Path):
+    assert load_digitization_log(tmp_path / "does_not_exist.yaml") is None
+
+
+def test_load_digitization_log_returns_none_for_none_path():
+    assert load_digitization_log(None) is None
+
+
+def test_load_digitization_log_parses_fixture(tmp_path: Path):
+    log_path = tmp_path / "digitization_log.yaml"
+    log_path.write_text(FIXTURE_YAML, encoding="utf-8")
+
+    log = load_digitization_log(log_path)
+
+    assert isinstance(log, DigitizationLog)
+    assert log.sourceDocuments[0].sourceTableID == "Table 4.2"
+    assert len(log.observations) == 2
+    assert log.normalizationSteps[0].field == "district_name"
+
+
+def test_already_explained_summary_includes_expected_but_not_needs_investigation(tmp_path: Path):
+    log_path = tmp_path / "digitization_log.yaml"
+    log_path.write_text(FIXTURE_YAML, encoding="utf-8")
+    log = load_digitization_log(log_path)
+
+    summary = log.already_explained_summary()
+    assert "obs-1" in summary
+    assert "Telangana" in summary
+    assert "obs-2" not in summary
+    assert "norm-1" in summary
+
+
+def test_needs_investigation_summary_includes_only_unresolved_observations(tmp_path: Path):
+    log_path = tmp_path / "digitization_log.yaml"
+    log_path.write_text(FIXTURE_YAML, encoding="utf-8")
+    log = load_digitization_log(log_path)
+
+    summary = log.needs_investigation_summary()
+    assert "obs-2" in summary
+    assert "obs-1" not in summary

--- a/src/dataio/api/tests/test_draft_prompt.py
+++ b/src/dataio/api/tests/test_draft_prompt.py
@@ -22,6 +22,21 @@ def _sample_profile(missing_source_columns=None):
     )
 
 
+def _sample_deterministic_base(table_name: str, data_dictionary: dict, enum_definitions: dict | None = None) -> dict:
+    """Matches the shape draft_service._infer_deterministic_base produces -
+    a fixture for tests that need to exercise build_prompt/build_batch_prompt's
+    deterministic-context rendering without going through the full inference
+    pipeline.
+    """
+    return {
+        "tables": {table_name: {"joinKeys": [], "data_dictionary": data_dictionary}},
+        "enum_definitions": enum_definitions or {},
+        "canonical_enum_definitions": {},
+        "join_keys": [],
+        "region_gap_comments": [],
+    }
+
+
 def test_build_prompt_includes_missing_source_columns():
     profile = _sample_profile(missing_source_columns=["sourceTableID", "sourcePage"])
     system_prompt, user_prompt = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
@@ -50,23 +65,103 @@ def test_build_prompt_includes_expected_observations_and_do_not_reflag_instructi
     assert "do not re-flag" in system_prompt.lower()
 
 
-def test_build_prompt_embeds_full_csv_text_when_provided():
+def test_build_prompt_never_embeds_raw_csv_row_data():
+    """Full CSV text is never sent to the LLM anymore - only the bounded
+    profile summary (stats + up to 20 sample rows, from _format_csv_profile)
+    plus the deterministic-context annotation. This is the fix for the
+    real production bug where a large table's full text alone blew past
+    the model's token limit.
+    """
     profile = _sample_profile()
-    _, user_prompt = build_prompt(
-        csv_profiles={"main": profile}, digitization_log=None, full_csv_texts={"main": "state,year\nA,1\n"}
+    _, user_prompt = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "Full CSV contents" not in user_prompt
+
+
+def test_build_prompt_includes_deterministic_context_when_provided():
+    profile = _sample_profile()
+    deterministic_base = _sample_deterministic_base(
+        "main", {"state": {"type": "regionName", "nullable": False, "description": None}}
     )
-    assert "Full CSV contents" in user_prompt
-    assert "state,year\nA,1" in user_prompt
+    _, user_prompt = build_prompt(
+        csv_profiles={"main": profile}, digitization_log=None, deterministic_base=deterministic_base
+    )
+
+    assert "columns needing a `description`" in user_prompt
+    assert "state: type=regionName" in user_prompt
 
 
-def test_system_prompt_lists_exact_supported_types_and_rejects_integer():
+def test_build_prompt_omits_columns_that_already_have_a_fixed_description():
+    """A column the deterministic pre-pass already gave a real description
+    to (region identifiers, source-provenance columns) must not be listed
+    as needing one - the LLM shouldn't waste a turn redoing settled work.
+    """
+    profile = _sample_profile()
+    deterministic_base = _sample_deterministic_base(
+        "main",
+        {
+            "state.ID": {"type": "regionID", "nullable": False, "description": "Prefixed LGD identifier."},
+            "count": {"type": "int", "nullable": True, "description": None},
+        },
+    )
+    _, user_prompt = build_prompt(
+        csv_profiles={"main": profile}, digitization_log=None, deterministic_base=deterministic_base
+    )
+
+    assert "state.ID" not in user_prompt.split("columns needing a `description`")[1].split("\n\n")[0]
+    assert "count: type=int" in user_prompt
+
+
+def test_build_prompt_includes_enum_context_for_enum_typed_columns():
+    profile = _sample_profile()
+    deterministic_base = _sample_deterministic_base(
+        "main",
+        {"species": {"type": "enum", "enumRef": "speciesEnum", "nullable": False, "description": None}},
+        enum_definitions={"speciesEnum": {"description": "x", "values": {"cattle": {"description": "cattle"}}}},
+    )
+    _, user_prompt = build_prompt(
+        csv_profiles={"main": profile}, digitization_log=None, deterministic_base=deterministic_base
+    )
+
+    assert "Enum blocks used by this table needing definitions" in user_prompt
+    assert "speciesEnum: values = ['cattle']" in user_prompt
+
+
+def test_system_prompt_no_longer_asks_for_column_typing():
+    """type/nullable/format/joinKeys/canonicalEnumDefinitions are all
+    decided deterministically now (field_inference.py) - the LLM is told
+    NOT to produce them (rather than given typing rules for how to produce
+    them itself), and the old regionID/LGD-pairing typing rules are gone
+    entirely.
+    """
     profile = _sample_profile()
     system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
 
-    assert '"int"' in system_prompt
-    assert "integer" not in system_prompt.lower().replace('"integer" is invalid', "")
-    assert "regionID" in system_prompt
-    assert "%Y" in system_prompt
+    assert "regionID" not in system_prompt
+    assert "lgd_code" not in system_prompt
+    assert "do NOT include" in system_prompt
+    assert "isJoinKey, or joinKeyType inside any" in system_prompt
+
+
+def test_system_prompt_tells_llm_not_to_produce_join_keys_or_canonical_enum_definitions():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "do not produce joinkeys or canonicalenumdefinitions" in system_prompt.lower()
+
+
+def test_system_prompt_no_longer_embeds_inl98_registry_text():
+    """canonicalEnumDefinitions (including the hardcoded INL-98 livestock
+    species/breed registry) is now looked up deterministically
+    (field_inference.lookup_canonical_enum_definitions against
+    canonical_enum_registry.yaml) - the LLM no longer needs, and must not
+    be shown, this registry text at all.
+    """
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "INL-98" not in system_prompt
+    assert "canonicalSpecies" not in system_prompt
 
 
 def test_build_prompt_surfaces_all_distinct_values_for_enum_candidate_columns():
@@ -167,14 +262,6 @@ flags: []
         parse_llm_output(text)
 
 
-def test_system_prompt_requires_lgd_code_paired_with_region_id_in_join_keys():
-    profile = _sample_profile()
-    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
-
-    assert "lgd_code" in system_prompt
-    assert "never include the regionID alone" in system_prompt or "never the regionID alone" in system_prompt
-
-
 def test_system_prompt_forbids_drafter_confidence_hedging_in_comments():
     profile = _sample_profile()
     system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
@@ -184,69 +271,52 @@ def test_system_prompt_forbids_drafter_confidence_hedging_in_comments():
     assert "not the drafting process" in lowered
 
 
-def test_system_prompt_mentions_canonical_enum_definitions_without_inventing_registry_id():
-    profile = _sample_profile()
-    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
-
-    assert "canonicalEnumDefinitions" in system_prompt
-    assert "do not invent a registry id" in system_prompt.lower()
-
-
-def test_system_prompt_reuses_established_inl98_registry_for_livestock_species():
-    """Every real dataset with a species/breed column reuses the exact same
-    INL-98 registry block (canonicalSpecies/canonicalBreed, with the
-    bovine/ovine_and_other_mammals groupings) - the drafter must be told to
-    reuse it verbatim rather than inventing a new block or leaving the ID
-    for the curator to assign, since one already exists for this concept.
-    """
-    profile = _sample_profile()
-    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
-
-    assert "INL-98" in system_prompt
-    assert "canonicalSpecies" in system_prompt
-    assert "canonicalBreed" in system_prompt
-    assert "ovine_and_other_mammals" in system_prompt
-    assert "bovine" in system_prompt
-
-
 def test_system_prompt_lists_fixed_top_level_keys_and_embeds_reference_template():
     profile = _sample_profile()
     system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
 
     assert "FIXED TOP-LEVEL KEYS" in system_prompt
     assert "metadata_field_reference.md" in system_prompt
-    # the embedded real-example template, trimmed from CS0007DS0112/CS0026DS0111
+    # the embedded real-example template, trimmed from CS0007DS0112
     assert "Reference example" in system_prompt
     assert "livestockSpecies" in system_prompt
 
 
-def test_build_batch_prompt_only_embeds_full_text_for_batch_tables():
+def test_build_batch_prompt_only_gives_context_for_batch_tables():
     """A table outside the current batch must still be named (for
-    cross-table context) but never get its full CSV content or a request
-    for a `tables:` entry - that's what keeps a later batch's call small.
+    cross-table context) but never get its profile stats or a request for
+    a `tables:` entry - that's what keeps a later batch's call small.
     """
     profile_a = _sample_profile()
     profile_b = CsvProfile(path="y.csv", row_count=5, columns=[], sample_rows_csv="species,count\ncattle,5\n")
+    deterministic_base = {
+        "tables": {
+            "table-one": {"joinKeys": [], "data_dictionary": {}},
+            "table-two": {"joinKeys": [], "data_dictionary": {}},
+        },
+        "enum_definitions": {},
+    }
     _, user_prompt = build_batch_prompt(
         csv_profiles={"table-one": profile_a, "table-two": profile_b},
         digitization_log=None,
-        full_csv_texts={"table-one": "state,year\nA,1\n", "table-two": "species,count\ncattle,5\n"},
+        deterministic_base=deterministic_base,
         batch_table_names=["table-one"],
         include_dataset_level_fields=True,
     )
 
     assert "table-two" in user_prompt  # named for context
     assert "context only" in user_prompt
-    assert "species,count\ncattle,5" not in user_prompt  # but its full content is withheld
-    assert "state,year\nA,1" in user_prompt  # batch's own table still gets full content
+    assert "species,count\ncattle,5" not in user_prompt  # its profile/samples are withheld
+    assert "state,year\nKarnataka,2019" in user_prompt  # batch's own table still gets its context
 
 
 def test_build_batch_prompt_first_batch_requests_dataset_level_fields():
     profile = _sample_profile()
+    deterministic_base = {"tables": {"main": {"joinKeys": [], "data_dictionary": {}}}, "enum_definitions": {}}
     _, user_prompt = build_batch_prompt(
         csv_profiles={"main": profile},
         digitization_log=None,
-        full_csv_texts={"main": "state,year\nA,1\n"},
+        deterministic_base=deterministic_base,
         batch_table_names=["main"],
         include_dataset_level_fields=True,
     )
@@ -257,10 +327,11 @@ def test_build_batch_prompt_first_batch_requests_dataset_level_fields():
 
 def test_build_batch_prompt_later_batch_omits_dataset_level_fields_request():
     profile = _sample_profile()
+    deterministic_base = {"tables": {"main": {"joinKeys": [], "data_dictionary": {}}}, "enum_definitions": {}}
     _, user_prompt = build_batch_prompt(
         csv_profiles={"main": profile},
         digitization_log=None,
-        full_csv_texts={"main": "state,year\nA,1\n"},
+        deterministic_base=deterministic_base,
         batch_table_names=["main"],
         include_dataset_level_fields=False,
     )

--- a/src/dataio/api/tests/test_draft_prompt.py
+++ b/src/dataio/api/tests/test_draft_prompt.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import pytest
+
+from dataio.api.services.csv_profiler import ColumnProfile, CsvProfile
+from dataio.api.services.digitization_log import DigitizationLog, Observation, NormalizationStep
+from dataio.api.services.draft_prompt import build_batch_prompt, build_prompt, parse_llm_output
+
+
+def _sample_profile(missing_source_columns=None):
+    return CsvProfile(
+        path="x.csv",
+        row_count=10,
+        columns=[
+            ColumnProfile(
+                name="state", dtype="object", null_count=0, null_fraction=0.0,
+                distinct_count=3, sample_values=["Karnataka", "Kerala"],
+            )
+        ],
+        missing_source_columns=missing_source_columns or [],
+        sample_rows_csv="state,year\nKarnataka,2019\n",
+    )
+
+
+def test_build_prompt_includes_missing_source_columns():
+    profile = _sample_profile(missing_source_columns=["sourceTableID", "sourcePage"])
+    system_prompt, user_prompt = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "sourceTableID" in user_prompt
+    assert "do NOT invent" in system_prompt or "Do NOT invent" in system_prompt
+
+
+def test_build_prompt_includes_expected_observations_and_do_not_reflag_instruction():
+    log = DigitizationLog(
+        observations=[
+            Observation(id="obs-1", description="Telangana absent pre-2014", resolution="expected"),
+            Observation(id="obs-2", description="unexplained negative values", resolution="needs_investigation"),
+        ],
+        normalizationSteps=[
+            NormalizationStep(id="norm-1", description="renamed column", field="district_name", changeType="rename"),
+        ],
+    )
+    profile = _sample_profile()
+    system_prompt, user_prompt = build_prompt(csv_profiles={"main": profile}, digitization_log=log)
+
+    assert "obs-1" in user_prompt
+    assert "Telangana" in user_prompt
+    assert "norm-1" in user_prompt
+    assert "obs-2" in user_prompt  # still surfaced, under "unresolved"
+    assert "do not re-flag" in system_prompt.lower()
+
+
+def test_build_prompt_embeds_full_csv_text_when_provided():
+    profile = _sample_profile()
+    _, user_prompt = build_prompt(
+        csv_profiles={"main": profile}, digitization_log=None, full_csv_texts={"main": "state,year\nA,1\n"}
+    )
+    assert "Full CSV contents" in user_prompt
+    assert "state,year\nA,1" in user_prompt
+
+
+def test_system_prompt_lists_exact_supported_types_and_rejects_integer():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert '"int"' in system_prompt
+    assert "integer" not in system_prompt.lower().replace('"integer" is invalid', "")
+    assert "regionID" in system_prompt
+    assert "%Y" in system_prompt
+
+
+def test_build_prompt_surfaces_all_distinct_values_for_enum_candidate_columns():
+    profile = CsvProfile(
+        path="x.csv",
+        row_count=3,
+        columns=[
+            ColumnProfile(
+                name="utility", dtype="object", null_count=0, null_fraction=0.0,
+                distinct_count=3, sample_values=["breeding only"],
+                all_distinct_values=["breeding & work", "breeding only", "work only"],
+            )
+        ],
+        sample_rows_csv="utility\nbreeding only\n",
+    )
+    _, user_prompt = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "breeding & work" in user_prompt
+    assert "all distinct values" in user_prompt
+
+
+def test_build_prompt_with_multiple_csvs_labels_each_table_by_its_own_name():
+    """Each uploaded CSV becomes its own table, named after that CSV's own
+    filename stem (see draft_service.generate_draft) - the prompt must show
+    each table separately, under its own name, not merge them into one.
+    """
+    profile_a = _sample_profile()
+    profile_b = CsvProfile(
+        path="y.csv", row_count=5, columns=[], sample_rows_csv="species,count\ncattle,5\n",
+    )
+    _, user_prompt = build_prompt(
+        csv_profiles={"table-one": profile_a, "table-two": profile_b}, digitization_log=None
+    )
+
+    assert "table-one" in user_prompt
+    assert "table-two" in user_prompt
+    assert "2 table(s)" in user_prompt
+
+
+def test_system_prompt_requires_exactly_one_table_per_csv_and_conditional_dataset_title():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "one entry per CSV table" in system_prompt or "one table per CSV" in system_prompt.lower()
+    assert "more than one csv table" in system_prompt.lower()
+
+
+def test_parse_llm_output_splits_manifest_and_flags():
+    text = """---MANIFEST---
+datasetTitle: Foo Dataset
+datasetSlug: foo-dataset
+---FLAGS---
+flags:
+  - field: sourceTableID
+    reason: not present in CSV
+"""
+    manifest, flags = parse_llm_output(text)
+
+    assert manifest["datasetTitle"] == "Foo Dataset"
+    assert flags == [{"field": "sourceTableID", "reason": "not present in CSV"}]
+
+
+def test_parse_llm_output_raises_on_missing_delimiters():
+    with pytest.raises(ValueError):
+        parse_llm_output("just some prose, not the expected format")
+
+
+def test_parse_llm_output_handles_no_flags():
+    text = """---MANIFEST---
+datasetTitle: Foo Dataset
+---FLAGS---
+flags: []
+"""
+    manifest, flags = parse_llm_output(text)
+    assert manifest["datasetTitle"] == "Foo Dataset"
+    assert flags == []
+
+
+def test_parse_llm_output_raises_value_error_on_malformed_manifest_yaml():
+    # Reproduces the exact failure the user hit in production: a multi-line
+    # plain-scalar list item (no block-scalar marker) directly followed by a
+    # quoted-string list item, which yaml.safe_load rejects with
+    # "expected <block end>, but found '<scalar>'".
+    text = """---MANIFEST---
+comments:
+  - Livestock Census years are irregular
+    and vary across states
+  - "locality" includes a 'total' value alongside
+    individual localities
+---FLAGS---
+flags: []
+"""
+    import yaml as _yaml
+    with pytest.raises(_yaml.YAMLError):
+        _yaml.safe_load(text.split("---MANIFEST---", 1)[1].split("---FLAGS---", 1)[0])
+
+    with pytest.raises(ValueError):
+        parse_llm_output(text)
+
+
+def test_system_prompt_requires_lgd_code_paired_with_region_id_in_join_keys():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "lgd_code" in system_prompt
+    assert "never include the regionID alone" in system_prompt or "never the regionID alone" in system_prompt
+
+
+def test_system_prompt_forbids_drafter_confidence_hedging_in_comments():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    lowered = system_prompt.lower()
+    assert "not fully confident" in lowered
+    assert "not the drafting process" in lowered
+
+
+def test_system_prompt_mentions_canonical_enum_definitions_without_inventing_registry_id():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "canonicalEnumDefinitions" in system_prompt
+    assert "do not invent a registry id" in system_prompt.lower()
+
+
+def test_system_prompt_reuses_established_inl98_registry_for_livestock_species():
+    """Every real dataset with a species/breed column reuses the exact same
+    INL-98 registry block (canonicalSpecies/canonicalBreed, with the
+    bovine/ovine_and_other_mammals groupings) - the drafter must be told to
+    reuse it verbatim rather than inventing a new block or leaving the ID
+    for the curator to assign, since one already exists for this concept.
+    """
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "INL-98" in system_prompt
+    assert "canonicalSpecies" in system_prompt
+    assert "canonicalBreed" in system_prompt
+    assert "ovine_and_other_mammals" in system_prompt
+    assert "bovine" in system_prompt
+
+
+def test_system_prompt_lists_fixed_top_level_keys_and_embeds_reference_template():
+    profile = _sample_profile()
+    system_prompt, _ = build_prompt(csv_profiles={"main": profile}, digitization_log=None)
+
+    assert "FIXED TOP-LEVEL KEYS" in system_prompt
+    assert "metadata_field_reference.md" in system_prompt
+    # the embedded real-example template, trimmed from CS0007DS0112/CS0026DS0111
+    assert "Reference example" in system_prompt
+    assert "livestockSpecies" in system_prompt
+
+
+def test_build_batch_prompt_only_embeds_full_text_for_batch_tables():
+    """A table outside the current batch must still be named (for
+    cross-table context) but never get its full CSV content or a request
+    for a `tables:` entry - that's what keeps a later batch's call small.
+    """
+    profile_a = _sample_profile()
+    profile_b = CsvProfile(path="y.csv", row_count=5, columns=[], sample_rows_csv="species,count\ncattle,5\n")
+    _, user_prompt = build_batch_prompt(
+        csv_profiles={"table-one": profile_a, "table-two": profile_b},
+        digitization_log=None,
+        full_csv_texts={"table-one": "state,year\nA,1\n", "table-two": "species,count\ncattle,5\n"},
+        batch_table_names=["table-one"],
+        include_dataset_level_fields=True,
+    )
+
+    assert "table-two" in user_prompt  # named for context
+    assert "context only" in user_prompt
+    assert "species,count\ncattle,5" not in user_prompt  # but its full content is withheld
+    assert "state,year\nA,1" in user_prompt  # batch's own table still gets full content
+
+
+def test_build_batch_prompt_first_batch_requests_dataset_level_fields():
+    profile = _sample_profile()
+    _, user_prompt = build_batch_prompt(
+        csv_profiles={"main": profile},
+        digitization_log=None,
+        full_csv_texts={"main": "state,year\nA,1\n"},
+        batch_table_names=["main"],
+        include_dataset_level_fields=True,
+    )
+
+    assert "FIRST call" in user_prompt
+    assert "datasetDescription" in user_prompt
+
+
+def test_build_batch_prompt_later_batch_omits_dataset_level_fields_request():
+    profile = _sample_profile()
+    _, user_prompt = build_batch_prompt(
+        csv_profiles={"main": profile},
+        digitization_log=None,
+        full_csv_texts={"main": "state,year\nA,1\n"},
+        batch_table_names=["main"],
+        include_dataset_level_fields=False,
+    )
+
+    assert "NOT the first call" in user_prompt
+    assert "Omit those keys entirely" in user_prompt

--- a/src/dataio/api/tests/test_draft_review_service.py
+++ b/src/dataio/api/tests/test_draft_review_service.py
@@ -428,6 +428,79 @@ def test_update_draft_content_rejects_editing_approved_or_rejected_draft(monkeyp
     assert exc_info.value.status_code == 400
 
 
+def test_generate_info_yaml_passes_draft_fields_to_the_builder(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(
+        dataset_id="CS0007DS0119",
+        collection_id="CS0007",
+        raw_dataset_id="CS0007RDS0005",
+        status=DatasetManifestDraftStatus.APPROVED,
+        draft_json={"datasetTitle": "Foo", "tables": {}},
+    )
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    recorded = {}
+
+    def fake_build(draft_json, *, dataset_id, collection_id, raw_dataset_id, access_level):
+        recorded.update(
+            draft_json=draft_json, dataset_id=dataset_id, collection_id=collection_id,
+            raw_dataset_id=raw_dataset_id, access_level=access_level,
+        )
+        return "ds_id: CS0007DS0119\n"
+
+    monkeypatch.setattr("dataio.api.services.info_yaml_builder.build_info_yaml", fake_build)
+
+    result = service.generate_info_yaml(str(draft.draft_id), "DOWNLOAD")
+
+    assert recorded["draft_json"] == {"datasetTitle": "Foo", "tables": {}}
+    assert recorded["dataset_id"] == "CS0007DS0119"
+    assert recorded["collection_id"] == "CS0007"
+    assert recorded["raw_dataset_id"] == "CS0007RDS0005"
+    assert recorded["access_level"] == "DOWNLOAD"
+    assert result == {"info_yaml": "ds_id: CS0007DS0119\n"}
+
+
+def test_generate_info_yaml_does_not_persist_anything(monkeypatch):
+    """Same non-persisting contract as update_draft_content/revalidate_draft
+    - this only returns text for the curator to download.
+    """
+    service = _make_service()
+    draft = _fake_draft(
+        status=DatasetManifestDraftStatus.APPROVED,
+        draft_json={"datasetTitle": "Foo", "tables": {}},
+    )
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("generate_info_yaml must not write to the database")
+
+    monkeypatch.setattr(service_module.database, "update_manifest_draft_content", fail_if_called)
+    monkeypatch.setattr(service_module.database, "update_manifest_draft_status", fail_if_called)
+
+    result = service.generate_info_yaml(str(draft.draft_id), "NONE")
+
+    assert "access_level: NONE" in result["info_yaml"]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [DatasetManifestDraftStatus.PENDING, DatasetManifestDraftStatus.FLAGGED, DatasetManifestDraftStatus.REJECTED],
+)
+def test_generate_info_yaml_rejects_a_draft_that_is_not_yet_approved(monkeypatch, status):
+    """info.yml must reflect the curator's *final* review, not a draft
+    that's still changeable - only generate it once approve_draft has
+    frozen the manifest (update_draft_content already refuses further
+    edits at that point).
+    """
+    service = _make_service()
+    draft = _fake_draft(status=status)
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.generate_info_yaml(str(draft.draft_id), "NONE")
+    assert exc_info.value.status_code == 400
+
+
 def test_get_draft_reports_whether_reserved_dataset_id_already_exists(monkeypatch):
     service = _make_service()
     draft = _fake_draft(dataset_id="CS0007DS0113")

--- a/src/dataio/api/tests/test_draft_review_service.py
+++ b/src/dataio/api/tests/test_draft_review_service.py
@@ -859,6 +859,48 @@ def test_classify_columns_splits_fixed_and_needs_description():
     assert set(result["needsDescription"]) == {"species", "count"}
 
 
+def test_infer_dataset_coverage_suggests_all_three_fields_from_real_csv(tmp_path):
+    csv_path = tmp_path / "main.csv"
+    csv_path.write_text(
+        "state.ID,state.name,year,count\n"
+        "state_KA,Karnataka,1997,10\n"
+        "state_KL,Kerala,2003,20\n"
+        "state_KA,Karnataka,2019,30\n",
+        encoding="utf-8",
+    )
+    service = _make_service()
+
+    result = service.infer_dataset_coverage([str(csv_path)])
+
+    assert result["spatialCoverage"] == "India"
+    assert result["spatialResolution"] == "state"
+    assert result["temporalCoverage"] == "1997, 2003, 2019"
+
+
+def test_infer_dataset_coverage_combines_across_multiple_tables(tmp_path):
+    coarse_csv = tmp_path / "coarse.csv"
+    coarse_csv.write_text("state.name,year,count\nKarnataka,1997,10\n", encoding="utf-8")
+    fine_csv = tmp_path / "fine.csv"
+    fine_csv.write_text("district.name,year,count\nBengaluru,2019,5\n", encoding="utf-8")
+    service = _make_service()
+
+    result = service.infer_dataset_coverage([str(coarse_csv), str(fine_csv)])
+
+    # finest resolution across both tables wins, and years union across both
+    assert result["spatialResolution"] == "district"
+    assert result["temporalCoverage"] == "1997, 2019"
+
+
+def test_infer_dataset_coverage_returns_none_when_nothing_detected(tmp_path):
+    csv_path = tmp_path / "plain.csv"
+    csv_path.write_text("indicator,count\nfoo,1\n", encoding="utf-8")
+    service = _make_service()
+
+    result = service.infer_dataset_coverage([str(csv_path)])
+
+    assert result == {"spatialCoverage": None, "spatialResolution": None, "temporalCoverage": None}
+
+
 def test_flag_field_delegates_to_db_function(monkeypatch):
     service = _make_service()
     draft = _fake_draft()

--- a/src/dataio/api/tests/test_draft_review_service.py
+++ b/src/dataio/api/tests/test_draft_review_service.py
@@ -14,6 +14,7 @@ os.environ.setdefault("DB_NAME", "catalogue")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 
 import pytest
+import yaml
 from fastapi import HTTPException
 
 from dataio.api.database.enums import DatasetManifestDraftStatus
@@ -233,6 +234,200 @@ def test_revalidate_draft_converts_and_uses_existing_validator(monkeypatch):
     assert recorded["data_files"] == {"main": draft.source_csv_path}
 
 
+def test_update_draft_content_revalidates_and_persists(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(draft_json={
+        "datasetTitle": "Foo",
+        "tables": {"main": {"description": "old", "data_dictionary": {"count": {"type": "int"}}}},
+    })
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    recorded = {}
+
+    class FakeValidator:
+        def validate_tabular(self, *, manifest, data_files, deep_check, full_scan):
+            recorded["manifest"] = manifest
+            return ValidationResult(dataset_kind="tabular")
+
+    monkeypatch.setattr(service_module, "DataIOValidator", FakeValidator)
+
+    def fake_update_content(draft_id, *, draft_yaml, draft_json, validation_result=None):
+        recorded["draft_yaml"] = draft_yaml
+        recorded["draft_json"] = draft_json
+        recorded["validation_result"] = validation_result
+        return _fake_draft(draft_yaml=draft_yaml, draft_json=draft_json)
+
+    monkeypatch.setattr(service_module.database, "update_manifest_draft_content", fake_update_content)
+
+    new_yaml = "datasetTitle: Foo\ntables:\n  main:\n    description: new and improved\n"
+    result = service.update_draft_content(str(draft.draft_id), new_yaml)
+
+    assert recorded["draft_yaml"] == new_yaml
+    assert recorded["draft_json"]["tables"]["main"]["description"] == "new and improved"
+    assert recorded["validation_result"]["dataset_kind"] == "tabular"
+    assert result["draft_yaml"] == new_yaml
+
+
+def test_update_draft_content_stringifies_yaml_implicit_dates(monkeypatch):
+    """yaml.safe_load silently parses an ISO-8601-looking scalar (e.g. a
+    temporalCoverage value like 2019-06-30) into a real datetime.date -
+    every manifest field is a plain string everywhere else in the app, and
+    the JSONB column's json serializer can't write a date object out, so
+    saving a curator edit containing one used to crash with a 500.
+    """
+    service = _make_service()
+    draft = _fake_draft(draft_json={"datasetTitle": "Foo", "tables": {}})
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    class FakeValidator:
+        def validate_tabular(self, *, manifest, data_files, deep_check, full_scan):
+            return ValidationResult(dataset_kind="tabular")
+
+    monkeypatch.setattr(service_module, "DataIOValidator", FakeValidator)
+
+    recorded = {}
+
+    def fake_update_content(draft_id, *, draft_yaml, draft_json, validation_result=None):
+        recorded["draft_json"] = draft_json
+        return _fake_draft(draft_yaml=draft_yaml, draft_json=draft_json)
+
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_content", fake_update_content
+    )
+
+    new_yaml = "datasetTitle: Foo\ntemporalCoverage: 2019-06-30\ntables: {}\n"
+    service.update_draft_content(str(draft.draft_id), new_yaml)
+
+    assert recorded["draft_json"]["temporalCoverage"] == "2019-06-30"
+    assert isinstance(recorded["draft_json"]["temporalCoverage"], str)
+
+
+def test_update_draft_content_reorders_keys_to_canonical_order(monkeypatch):
+    """A full-manifest save (e.g. the Draft Review screen's numeric-field
+    "Apply" action, or a raw YAML edit) submits draft_json in whatever key
+    order it happened to come back in from the DB's JSONB column, which
+    does not preserve insertion order - both the persisted draft_json and
+    the regenerated draft_yaml must come back in the same canonical order
+    every real metadata.yaml uses (datasetTitle, ..., source, ..., tables).
+    """
+    service = _make_service()
+    draft = _fake_draft(draft_json={"datasetTitle": "Foo", "tables": {}})
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    class FakeValidator:
+        def validate_tabular(self, *, manifest, data_files, deep_check, full_scan):
+            return ValidationResult(dataset_kind="tabular")
+
+    monkeypatch.setattr(service_module, "DataIOValidator", FakeValidator)
+
+    recorded = {}
+
+    def fake_update_content(draft_id, *, draft_yaml, draft_json, validation_result=None):
+        recorded["draft_yaml"] = draft_yaml
+        recorded["draft_json"] = draft_json
+        return _fake_draft(draft_yaml=draft_yaml, draft_json=draft_json)
+
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_content", fake_update_content
+    )
+
+    # Keys deliberately out of canonical order, as a JSONB round-trip would
+    # scramble them.
+    scrambled_yaml = "tables: {}\nsource: []\ndatasetTitle: Foo\n"
+    service.update_draft_content(str(draft.draft_id), scrambled_yaml)
+
+    assert list(recorded["draft_json"].keys()) == ["datasetTitle", "source", "tables"]
+    assert recorded["draft_yaml"].index("datasetTitle") < recorded["draft_yaml"].index("source")
+    assert recorded["draft_yaml"].index("source") < recorded["draft_yaml"].index("tables")
+
+
+def test_update_draft_content_restores_data_dictionary_column_and_field_order(
+    monkeypatch, tmp_path
+):
+    """The same JSONB-order-loss problem hits nested structure too: a
+    data_dictionary's column order and each field's own key order (e.g.
+    "min" ending up before "type") both get scrambled by a round-trip. The
+    fix re-derives column order from the table's own CSV header (the true
+    source of "natural" order) and re-canonicalizes each field's own keys.
+    """
+    service = _make_service()
+    csv_path = tmp_path / "main.csv"
+    csv_path.write_text("state.ID,year,species,count\n", encoding="utf-8")
+    draft = _fake_draft(
+        source_csv_path=f'{{"main": "{csv_path.as_posix()}"}}',
+        draft_json={
+            "datasetTitle": "Foo",
+            "tables": {
+                "main": {
+                    "description": "d",
+                    "data_dictionary": {
+                        # Deliberately out of CSV-header order, and each
+                        # field's own keys deliberately scrambled too.
+                        "count": {"min": 0, "type": "int", "additive": True},
+                        "state.ID": {"nullable": False, "type": "regionID"},
+                        "species": {"type": "enum", "enumRef": "speciesEnum"},
+                        "year": {"type": "date", "format": "%Y"},
+                    },
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    class FakeValidator:
+        def validate_tabular(self, *, manifest, data_files, deep_check, full_scan):
+            return ValidationResult(dataset_kind="tabular")
+
+    monkeypatch.setattr(service_module, "DataIOValidator", FakeValidator)
+
+    recorded = {}
+
+    def fake_update_content(draft_id, *, draft_yaml, draft_json, validation_result=None):
+        recorded["draft_json"] = draft_json
+        return _fake_draft(draft_yaml=draft_yaml, draft_json=draft_json)
+
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_content", fake_update_content
+    )
+
+    service.update_draft_content(str(draft.draft_id), yaml.safe_dump(draft.draft_json))
+
+    data_dictionary = recorded["draft_json"]["tables"]["main"]["data_dictionary"]
+    assert list(data_dictionary.keys()) == ["state.ID", "year", "species", "count"]
+    assert list(data_dictionary["count"].keys()) == ["type", "additive", "min"]
+
+
+def test_update_draft_content_rejects_invalid_yaml(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.update_draft_content(str(draft.draft_id), "not: valid: yaml: at: all:")
+    assert exc_info.value.status_code == 400
+
+
+def test_update_draft_content_rejects_non_mapping_yaml(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.update_draft_content(str(draft.draft_id), "- just\n- a\n- list\n")
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("status", [DatasetManifestDraftStatus.APPROVED, DatasetManifestDraftStatus.REJECTED])
+def test_update_draft_content_rejects_editing_approved_or_rejected_draft(monkeypatch, status):
+    service = _make_service()
+    draft = _fake_draft(status=status)
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.update_draft_content(str(draft.draft_id), "datasetTitle: Foo\n")
+    assert exc_info.value.status_code == 400
+
+
 def test_get_draft_reports_whether_reserved_dataset_id_already_exists(monkeypatch):
     service = _make_service()
     draft = _fake_draft(dataset_id="CS0007DS0113")
@@ -426,6 +621,169 @@ def test_generate_draft_from_upload_wraps_failures_as_502(monkeypatch):
             created_by="engineer@artpark.in",
         )
     assert exc_info.value.status_code == 502
+
+
+def _valid_curator_input(**overrides) -> dict:
+    defaults = dict(
+        datasetDescription="desc",
+        spatialCoverage="India",
+        spatialResolution="state",
+        temporalCoverage="1997-2019",
+        temporalResolution="annual",
+        updateFrequency="annual",
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def test_generate_deterministic_draft_from_upload_saves_files_and_calls_generator(monkeypatch):
+    import io
+
+    from fastapi import UploadFile
+
+    service = _make_service()
+    saved_paths = iter(["/tmp/csv-abc.csv"])
+    monkeypatch.setattr(service_module, "save_upload", lambda upload_file: next(saved_paths))
+
+    recorded = {}
+
+    def fake_generate_deterministic_draft(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(model_dump=lambda: {"draft_id": "new-draft-id", "status": "pending"})
+
+    monkeypatch.setattr(
+        "dataio.api.services.deterministic_draft_service.generate_deterministic_draft",
+        fake_generate_deterministic_draft,
+    )
+
+    result = service.generate_deterministic_draft_from_upload(
+        csv_files=[UploadFile(filename="data.csv", file=io.BytesIO(b"a,b\n1,2\n"))],
+        category_id="CS",
+        collection_id="CS0007",
+        data_owner_name="DAHD",
+        created_by="engineer@artpark.in",
+        curator_input=_valid_curator_input(),
+    )
+
+    assert recorded["csv_paths"] == ["/tmp/csv-abc.csv"]
+    assert recorded["curator_input"].datasetDescription == "desc"
+    assert result["draft_id"] == "new-draft-id"
+
+
+def test_generate_deterministic_draft_from_upload_rejects_invalid_curator_input(monkeypatch):
+    service = _make_service()
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.generate_deterministic_draft_from_upload(
+            csv_files=[],
+            category_id="CS",
+            collection_id="CS0007",
+            data_owner_name="DAHD",
+            created_by="engineer@artpark.in",
+            curator_input={},  # missing every required field
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_generate_deterministic_draft_from_upload_wraps_failures_as_502(monkeypatch):
+    import io
+
+    from fastapi import UploadFile
+
+    service = _make_service()
+    monkeypatch.setattr(service_module, "save_upload", lambda upload_file: "/tmp/csv-abc.csv")
+
+    def failing_generate(**kwargs):
+        raise RuntimeError("profiling blew up")
+
+    monkeypatch.setattr(
+        "dataio.api.services.deterministic_draft_service.generate_deterministic_draft",
+        failing_generate,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.generate_deterministic_draft_from_upload(
+            csv_files=[UploadFile(filename="data.csv", file=io.BytesIO(b"a,b\n1,2\n"))],
+            category_id="CS",
+            collection_id="CS0007",
+            data_owner_name="DAHD",
+            created_by="engineer@artpark.in",
+            curator_input=_valid_curator_input(),
+        )
+    assert exc_info.value.status_code == 502
+
+
+def test_regenerate_draft_dispatches_to_deterministic_path_when_llm_model_id_is_none(monkeypatch):
+    """A draft with llm_model_id=None was produced by the deterministic
+    path (see generate_deterministic_draft_from_upload), so regenerating it
+    must reconstruct a CuratorMetadataInput from the original draft_json and
+    re-run generate_deterministic_draft - not the LLM's generate_draft.
+    """
+    service = _make_service()
+    original = _fake_draft(
+        llm_model_id=None,
+        raw_dataset_id="CSRDS0016",
+        draft_json={
+            "datasetTitle": "Foo",
+            "datasetDescription": "desc",
+            "source": ["https://example.com"],
+            "references": [],
+            "tags": {"concept": ["livestock"], "epiType": []},
+            "spatialCoverage": "India",
+            "spatialResolution": "state",
+            "temporalCoverage": "1997-2019",
+            "temporalResolution": "annual",
+            "updateFrequency": "annual",
+            "joinKeys": ["state.ID", "year"],
+            # A region-history comment must NOT round-trip verbatim -
+            # generate_deterministic_draft recomputes and re-appends those
+            # fresh, so carrying the old one forward would duplicate it.
+            "comments": ["curator note", "[region history] Telangana was carved out of Andhra Pradesh..."],
+            "tables": {"main": {"description": "d", "data_dictionary": {"count": {"type": "int"}}}},
+        },
+    )
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: original)
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_status",
+        lambda draft_id, status, **kw: None,
+    )
+    monkeypatch.setattr(
+        "dataio.api.services.draft_service.decode_csv_paths",
+        lambda source_csv_path, table_names=None: {"main": "foo.csv"},
+    )
+
+    recorded = {}
+
+    def fake_generate_deterministic_draft(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(model_dump=lambda: {"draft_id": "new-draft-id", "status": "pending"})
+
+    monkeypatch.setattr(
+        "dataio.api.services.deterministic_draft_service.generate_deterministic_draft",
+        fake_generate_deterministic_draft,
+    )
+
+    result = service.regenerate_draft(str(original.draft_id), "reviewer@artpark.in")
+
+    assert recorded["raw_dataset_id"] == "CSRDS0016"
+    assert recorded["curator_input"].comments == ["curator note"]
+    assert recorded["curator_input"].joinKeyColumns == ["state.ID", "year"]
+    assert recorded["curator_input"].tableDescriptions == {"main": "d"}
+    assert recorded["curator_input"].datasetTitle == "Foo"
+    assert result["draft_id"] == "new-draft-id"
+
+
+def test_classify_columns_splits_fixed_and_needs_description():
+    service = _make_service()
+
+    result = service.classify_columns(
+        column_names=[
+            "state.ID", "state.name", "state.lgd_code", "sourceDocument", "species", "count",
+        ],
+    )
+
+    assert set(result["fixed"]) == {"state.ID", "state.name", "state.lgd_code", "sourceDocument"}
+    assert set(result["needsDescription"]) == {"species", "count"}
 
 
 def test_flag_field_delegates_to_db_function(monkeypatch):

--- a/src/dataio/api/tests/test_draft_review_service.py
+++ b/src/dataio/api/tests/test_draft_review_service.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+import pytest
+from fastapi import HTTPException
+
+from dataio.api.database.enums import DatasetManifestDraftStatus
+from dataio.api.services import draft_review_service as service_module
+from dataio.api.services.draft_review_service import DraftReviewService
+from dataio.validate.reports.models import ValidationResult
+
+
+def _fake_draft(**overrides):
+    defaults = dict(
+        draft_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        dataset_id="CS0007DS0112",
+        collection_id="CS0007",
+        category_id="CS",
+        source_csv_path="foo.csv",
+        digitization_log_path=None,
+        raw_dataset_id="CSRDS0016",
+        status=DatasetManifestDraftStatus.PENDING,
+        draft_yaml="datasetTitle: Foo\n",
+        draft_json={
+            "datasetTitle": "Foo",
+            "tables": {"main": {"description": "d", "data_dictionary": {"count": {"type": "int"}}}},
+        },
+        flagged_fields=[],
+        reviewer_notes=[],
+        validation_result=None,
+        llm_model_id="anthropic/claude-3.5-sonnet",
+        created_by="engineer@artpark.in",
+        created_at=datetime(2026, 7, 21),
+        reviewed_by=None,
+        reviewed_at=None,
+        superseded_by_draft_id=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_service():
+    service = object.__new__(DraftReviewService)
+    service.logger = logging.getLogger(__name__)
+    return service
+
+
+def test_get_draft_raises_404_when_missing(monkeypatch):
+    service = _make_service()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.get_draft("does-not-exist")
+    assert exc_info.value.status_code == 404
+
+
+def test_list_drafts_returns_serialized_rows(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "list_manifest_drafts", lambda **kw: ([draft], 1))
+
+    result = service.list_drafts(status="pending")
+
+    assert result["total"] == 1
+    assert result["drafts"][0]["draft_id"] == str(draft.draft_id)
+    assert result["drafts"][0]["status"] == "pending"
+
+
+def test_delete_draft_raises_404_when_missing(monkeypatch):
+    service = _make_service()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.delete_draft("does-not-exist")
+    assert exc_info.value.status_code == 404
+
+
+def test_delete_draft_calls_db_delete(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+
+    recorded = {}
+    monkeypatch.setattr(
+        service_module.database, "delete_manifest_draft",
+        lambda draft_id: recorded.setdefault("deleted_id", draft_id),
+    )
+
+    service.delete_draft(str(draft.draft_id))
+
+    assert recorded["deleted_id"] == str(draft.draft_id)
+
+
+def test_delete_draft_releases_reservation_when_dataset_not_yet_created(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(dataset_id="CS0007DS0999")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: False)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+    monkeypatch.setattr(service_module.database, "delete_manifest_draft", lambda draft_id: None)
+
+    recorded = {}
+    monkeypatch.setattr(
+        service_module, "delete_reserved_dataset_id",
+        lambda ds_id: recorded.setdefault("released_id", ds_id),
+    )
+
+    service.delete_draft(str(draft.draft_id))
+
+    assert recorded["released_id"] == "CS0007DS0999"
+
+
+def test_delete_draft_leaves_reservation_alone_when_dataset_already_exists(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(dataset_id="CS0007DS0112")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+    monkeypatch.setattr(service_module.database, "delete_manifest_draft", lambda draft_id: None)
+
+    def fail_if_called(ds_id):
+        raise AssertionError("should not release a reservation for a dataset that already exists")
+
+    monkeypatch.setattr(service_module, "delete_reserved_dataset_id", fail_if_called)
+
+    service.delete_draft(str(draft.draft_id))
+
+
+def test_delete_draft_releases_raw_dataset_reservation_when_not_yet_created(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(raw_dataset_id="CSRDS0099")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: False)
+    monkeypatch.setattr(service_module.database, "delete_manifest_draft", lambda draft_id: None)
+
+    recorded = {}
+    monkeypatch.setattr(
+        service_module, "delete_reserved_raw_dataset_id",
+        lambda rds_id: recorded.setdefault("released_id", rds_id),
+    )
+
+    service.delete_draft(str(draft.draft_id))
+
+    assert recorded["released_id"] == "CSRDS0099"
+
+
+def test_delete_draft_leaves_raw_dataset_reservation_alone_when_already_created(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(raw_dataset_id="CSRDS0016")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+    monkeypatch.setattr(service_module.database, "delete_manifest_draft", lambda draft_id: None)
+
+    def fail_if_called(rds_id):
+        raise AssertionError("should not release a reservation for a raw dataset that already exists")
+
+    monkeypatch.setattr(service_module, "delete_reserved_raw_dataset_id", fail_if_called)
+
+    service.delete_draft(str(draft.draft_id))
+
+
+def test_delete_draft_cleans_up_uploaded_files(monkeypatch, tmp_path):
+    service = _make_service()
+    csv_path = tmp_path / "foo.csv"
+    csv_path.write_text("a,b\n1,2\n")
+    log_path = tmp_path / "log.yaml"
+    log_path.write_text("notes: x")
+
+    draft = _fake_draft(
+        source_csv_path=f'{{"main": "{csv_path.as_posix()}"}}',
+        digitization_log_path=str(log_path),
+    )
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+    monkeypatch.setattr(service_module.database, "delete_manifest_draft", lambda draft_id: None)
+
+    service.delete_draft(str(draft.draft_id))
+
+    assert not csv_path.exists()
+    assert not log_path.exists()
+
+
+def test_revalidate_draft_converts_and_uses_existing_validator(monkeypatch):
+    """revalidate_draft must go through the same conversion +
+    DataIOValidator generate_draft() uses - not a separate/parallel
+    validator - matching how every real dataset is actually checked.
+    """
+    service = _make_service()
+    draft = _fake_draft(draft_json={
+        "datasetTitle": "Foo",
+        "tables": {"main": {"description": "d", "data_dictionary": {"count": {"type": "int"}}}},
+    })
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    recorded = {}
+
+    class FakeValidator:
+        def validate_tabular(self, *, manifest, data_files, deep_check, full_scan):
+            recorded["manifest"] = manifest
+            recorded["data_files"] = data_files
+            return ValidationResult(dataset_kind="tabular")
+
+    monkeypatch.setattr(service_module, "DataIOValidator", FakeValidator)
+
+    def fake_update_status(draft_id, status, **kw):
+        recorded["kwargs"] = kw
+        return _fake_draft()
+
+    monkeypatch.setattr(service_module.database, "update_manifest_draft_status", fake_update_status)
+
+    service.revalidate_draft(str(draft.draft_id))
+
+    assert recorded["kwargs"]["validation_result"]["dataset_kind"] == "tabular"
+    assert "datasetTables" in recorded["manifest"]
+    assert "tables:" not in recorded["manifest"]
+    assert recorded["data_files"] == {"main": draft.source_csv_path}
+
+
+def test_get_draft_reports_whether_reserved_dataset_id_already_exists(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft(dataset_id="CS0007DS0113")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: False)
+
+    result = service.get_draft(str(draft.draft_id))
+
+    assert result["dataset_id"] == "CS0007DS0113"
+    assert result["dataset_exists"] is False
+
+
+def test_approve_draft_marks_status_approved(monkeypatch):
+    """approve_draft is deliberately lightweight now - this tool only
+    generates/validates/downloads, it doesn't upload anything. Approving
+    just records the curator's acceptance; the dataset_id stays whatever
+    was reserved at generation time, untouched.
+    """
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    recorded = {}
+
+    def fake_update_status(draft_id, status, **kw):
+        recorded["draft_id"] = draft_id
+        recorded["status"] = status
+        recorded["kwargs"] = kw
+        return _fake_draft(status=DatasetManifestDraftStatus.APPROVED)
+
+    monkeypatch.setattr(service_module.database, "update_manifest_draft_status", fake_update_status)
+
+    result = service.approve_draft(str(draft.draft_id), "reviewer@artpark.in")
+
+    assert recorded["draft_id"] == str(draft.draft_id)
+    assert recorded["status"] == "approved"
+    assert recorded["kwargs"]["reviewed_by"] == "reviewer@artpark.in"
+    assert result["status"] == "approved"
+
+
+def test_approve_draft_raises_404_when_missing(monkeypatch):
+    service = _make_service()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.approve_draft("does-not-exist", "reviewer@artpark.in")
+    assert exc_info.value.status_code == 404
+
+
+def test_reject_draft_records_reason(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    recorded = {}
+
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: True)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: True)
+    monkeypatch.setattr(
+        service_module.database, "append_manifest_draft_note",
+        lambda draft_id, note: recorded.setdefault("note", note),
+    )
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_status",
+        lambda draft_id, status, **kw: _fake_draft(status=DatasetManifestDraftStatus.REJECTED),
+    )
+
+    result = service.reject_draft(str(draft.draft_id), "reviewer@artpark.in", reason="not accurate")
+
+    assert recorded["note"]["note"] == "not accurate"
+    assert result["status"] == "rejected"
+
+
+def test_reject_draft_releases_reservations_when_not_yet_created(monkeypatch):
+    """Unlike regenerate_draft (which marks the original rejected via the
+    raw database function directly, bypassing this release), a plain
+    reject through this service method must free up both reservations -
+    otherwise reject-and-restart cycles permanently burn through the
+    global/category id counters for nothing.
+    """
+    service = _make_service()
+    draft = _fake_draft(dataset_id="CS0007DS0999", raw_dataset_id="CSRDS0099")
+
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+    monkeypatch.setattr(service_module.database, "check_if_dataset_exists", lambda dataset_id: False)
+    monkeypatch.setattr(service_module, "check_if_raw_dataset_exists", lambda rds_id: False)
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_status",
+        lambda draft_id, status, **kw: _fake_draft(status=DatasetManifestDraftStatus.REJECTED),
+    )
+
+    released = {}
+    monkeypatch.setattr(
+        service_module, "delete_reserved_dataset_id",
+        lambda ds_id: released.setdefault("ds_id", ds_id),
+    )
+    monkeypatch.setattr(
+        service_module, "delete_reserved_raw_dataset_id",
+        lambda rds_id: released.setdefault("rds_id", rds_id),
+    )
+
+    service.reject_draft(str(draft.draft_id), "reviewer@artpark.in")
+
+    assert released["ds_id"] == "CS0007DS0999"
+    assert released["rds_id"] == "CSRDS0099"
+
+
+def test_generate_draft_from_upload_saves_files_and_calls_generate_draft(monkeypatch, tmp_path):
+    import io
+
+    from fastapi import UploadFile
+
+    service = _make_service()
+
+    saved_paths = iter(["/tmp/csv-abc.csv", "/tmp/log-abc.yaml"])
+    monkeypatch.setattr(service_module, "save_upload", lambda upload_file: next(saved_paths))
+
+    recorded = {}
+
+    def fake_generate_draft(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(model_dump=lambda: {"draft_id": "new-draft-id", "status": "pending"})
+
+    monkeypatch.setattr("dataio.api.services.draft_service.generate_draft", fake_generate_draft)
+
+    result = service.generate_draft_from_upload(
+        csv_files=[UploadFile(filename="data.csv", file=io.BytesIO(b"a,b\n1,2\n"))],
+        category_id="CS",
+        collection_id="CS0007",
+        data_owner_name="DAHD",
+        created_by="engineer@artpark.in",
+        digitization_log_file=UploadFile(filename="log.yaml", file=io.BytesIO(b"notes: x")),
+    )
+
+    assert recorded["csv_paths"] == ["/tmp/csv-abc.csv"]
+    assert recorded["digitization_log_path"] == "/tmp/log-abc.yaml"
+    assert recorded["category_id"] == "CS"
+    assert result["draft_id"] == "new-draft-id"
+
+
+def test_generate_draft_from_upload_saves_multiple_csvs(monkeypatch):
+    import io
+
+    from fastapi import UploadFile
+
+    service = _make_service()
+
+    saved_paths = iter(["/tmp/a.csv", "/tmp/b.csv"])
+    monkeypatch.setattr(service_module, "save_upload", lambda upload_file: next(saved_paths))
+
+    recorded = {}
+
+    def fake_generate_draft(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(model_dump=lambda: {"draft_id": "new-draft-id", "status": "pending"})
+
+    monkeypatch.setattr("dataio.api.services.draft_service.generate_draft", fake_generate_draft)
+
+    service.generate_draft_from_upload(
+        csv_files=[
+            UploadFile(filename="a.csv", file=io.BytesIO(b"a,b\n1,2\n")),
+            UploadFile(filename="b.csv", file=io.BytesIO(b"c,d\n3,4\n")),
+        ],
+        category_id="CS",
+        collection_id="CS0007",
+        data_owner_name="DAHD",
+        created_by="engineer@artpark.in",
+    )
+
+    assert recorded["csv_paths"] == ["/tmp/a.csv", "/tmp/b.csv"]
+
+
+def test_generate_draft_from_upload_wraps_failures_as_502(monkeypatch):
+    import io
+
+    from fastapi import UploadFile
+
+    service = _make_service()
+    monkeypatch.setattr(service_module, "save_upload", lambda upload_file: "/tmp/csv-abc.csv")
+
+    def failing_generate_draft(**kwargs):
+        raise RuntimeError("OpenRouter is down")
+
+    monkeypatch.setattr("dataio.api.services.draft_service.generate_draft", failing_generate_draft)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.generate_draft_from_upload(
+            csv_files=[UploadFile(filename="data.csv", file=io.BytesIO(b"a,b\n1,2\n"))],
+            category_id="CS",
+            collection_id="CS0007",
+            data_owner_name="DAHD",
+            created_by="engineer@artpark.in",
+        )
+    assert exc_info.value.status_code == 502
+
+
+def test_flag_field_delegates_to_db_function(monkeypatch):
+    service = _make_service()
+    draft = _fake_draft()
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: draft)
+
+    recorded = {}
+
+    def fake_flag(draft_id, field_path, reason, flagged_by):
+        recorded.update(draft_id=draft_id, field_path=field_path, reason=reason, flagged_by=flagged_by)
+        return _fake_draft(status=DatasetManifestDraftStatus.FLAGGED, flagged_fields=[{"field": field_path, "reason": reason}])
+
+    monkeypatch.setattr(service_module.database, "flag_manifest_draft_field", fake_flag)
+
+    result = service.flag_field(str(draft.draft_id), "sourceTableID", "missing from CSV", "reviewer@artpark.in")
+
+    assert recorded["field_path"] == "sourceTableID"
+    assert result["status"] == "flagged"
+
+
+def test_regenerate_draft_reuses_original_raw_dataset_id(monkeypatch):
+    """The new draft must reuse the original's raw_dataset_id rather than
+    reserving a fresh one - this is a redraft of the same dataset, not a
+    new one, and generate_draft's own raw_dataset_id passthrough (tested in
+    test_draft_service.py) is what makes reuse-not-reserve possible.
+    """
+    service = _make_service()
+    original = _fake_draft(raw_dataset_id="CSRDS0016")
+    monkeypatch.setattr(service_module.database, "get_manifest_draft", lambda draft_id: original)
+    monkeypatch.setattr(
+        service_module.database, "update_manifest_draft_status",
+        lambda draft_id, status, **kw: None,
+    )
+
+    recorded = {}
+
+    def fake_generate_draft(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(model_dump=lambda: {"draft_id": "new-draft-id", "status": "pending"})
+
+    monkeypatch.setattr("dataio.api.services.draft_service.generate_draft", fake_generate_draft)
+    monkeypatch.setattr(
+        "dataio.api.services.draft_service.decode_csv_paths",
+        lambda source_csv_path, table_names=None: {"main": "foo.csv"},
+    )
+
+    result = service.regenerate_draft(str(original.draft_id), "reviewer@artpark.in")
+
+    assert recorded["raw_dataset_id"] == "CSRDS0016"
+    assert result["draft_id"] == "new-draft-id"

--- a/src/dataio/api/tests/test_draft_service.py
+++ b/src/dataio/api/tests/test_draft_service.py
@@ -12,14 +12,14 @@ os.environ.setdefault("DB_NAME", "catalogue")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 
 from dataio.api.services import draft_service
-from dataio.api.services.csv_profiler import CsvProfile
+from dataio.api.services.csv_profiler import ColumnProfile, CsvProfile
 from dataio.validate.reports.models import ValidationResult
 
 LLM_RESPONSE = """---MANIFEST---
 datasetTitle: Foo Dataset
 datasetSlug: foo-dataset
 tables:
-  main:
+  foo:
     description: table
 ---FLAGS---
 flags:
@@ -56,7 +56,6 @@ class FakeOpenRouterClient:
 def _patch_common(monkeypatch, missing_source_columns=None):
     monkeypatch.setattr(draft_service, "profile_csv", lambda path: _stub_csv_profile(missing_source_columns))
     monkeypatch.setattr(draft_service, "load_digitization_log", lambda path: None)
-    monkeypatch.setattr(draft_service, "read_full_csv_text", lambda path: "a,b\n1,2\n")
     monkeypatch.setattr(draft_service, "OpenRouterDraftClient", FakeOpenRouterClient)
     monkeypatch.setattr(
         draft_service, "_validate_manifest",
@@ -267,28 +266,28 @@ def test_generate_draft_flags_missing_source_columns(monkeypatch):
 
 
 def test_batch_tables_groups_by_cumulative_size():
-    full_csv_texts = {"a": "x" * 40, "b": "x" * 40, "c": "x" * 40}
+    context_sizes = {"a": 40, "b": 40, "c": 40}
 
-    batches = draft_service._batch_tables(["a", "b", "c"], full_csv_texts, char_budget=100)
+    batches = draft_service._batch_tables(["a", "b", "c"], context_sizes, char_budget=100)
 
     # a+b = 80 (fits), c alone starts a new batch (80 + 40 > 100)
     assert batches == [["a", "b"], ["c"]]
 
 
 def test_batch_tables_puts_oversized_single_table_in_its_own_batch():
-    full_csv_texts = {"huge": "x" * 500, "small": "x" * 10}
+    context_sizes = {"huge": 500, "small": 10}
 
-    batches = draft_service._batch_tables(["huge", "small"], full_csv_texts, char_budget=100)
+    batches = draft_service._batch_tables(["huge", "small"], context_sizes, char_budget=100)
 
     # "huge" alone already exceeds the budget, but is never dropped/split -
-    # it still gets its own solo batch with its full content intact.
+    # it still gets its own solo batch with its full context intact.
     assert batches == [["huge"], ["small"]]
 
 
 def test_batch_tables_single_table_under_budget_is_one_batch():
-    full_csv_texts = {"only": "x" * 10}
+    context_sizes = {"only": 10}
 
-    assert draft_service._batch_tables(["only"], full_csv_texts, char_budget=100) == [["only"]]
+    assert draft_service._batch_tables(["only"], context_sizes, char_budget=100) == [["only"]]
 
 
 def test_merge_batch_manifests_single_batch_passes_through_unchanged():
@@ -365,17 +364,17 @@ def test_merge_batch_manifests_unions_tags_and_enum_definitions():
 
 
 def test_generate_draft_splits_dataset_into_multiple_batches_when_over_char_budget(monkeypatch):
-    """A dataset whose combined full-CSV-text exceeds BATCH_CHAR_BUDGET must
-    be drafted over multiple LLM calls (one per table here, given the tiny
-    monkeypatched budget) rather than one oversized call - and the batches'
-    results must be merged into one manifest.
+    """A dataset whose combined prompt-context size exceeds BATCH_CHAR_BUDGET
+    must be drafted over multiple LLM calls (one per table here, given the
+    tiny monkeypatched budget) rather than one oversized call - and the
+    batches' results must be merged into one manifest.
     """
     _patch_common(monkeypatch)
     monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
     monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
     monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
     monkeypatch.setattr(draft_service, "BATCH_CHAR_BUDGET", 10)
-    monkeypatch.setattr(draft_service, "read_full_csv_text", lambda path: "x" * 20)
+    monkeypatch.setattr(draft_service, "estimate_table_context_size", lambda table_name, profile, table_base=None: 20)
 
     calls = []
 
@@ -421,6 +420,208 @@ def test_generate_draft_splits_dataset_into_multiple_batches_when_over_char_budg
     assert set(result.draft_json["tables"].keys()) == {"foo", "bar", "baz"}
     assert result.draft_json["datasetDescription"] == "shared description"  # only the first batch supplied it
     assert {f["field"] for f in result.flagged_fields} == {"foo_col", "bar_col", "baz_col"}
+
+
+def test_infer_deterministic_base_types_columns_and_matches_canonical_enum():
+    profile = CsvProfile(
+        path="fake.csv",
+        row_count=10,
+        columns=[
+            ColumnProfile(
+                name="species", dtype="object", null_count=0, null_fraction=0.0,
+                distinct_count=2, sample_values=["cattle", "buffalo"],
+                all_distinct_values=["cattle", "buffalo"],
+            ),
+            ColumnProfile(
+                name="count", dtype="int64", null_count=1, null_fraction=0.1,
+                distinct_count=5, sample_values=["1", "2"],
+            ),
+        ],
+        sample_rows_csv="species,count\ncattle,1\n",
+    )
+
+    base = draft_service._infer_deterministic_base({"main": profile}, {"main": "fake.csv"})
+
+    data_dictionary = base["tables"]["main"]["data_dictionary"]
+    assert data_dictionary["species"]["type"] == "enum"
+    assert data_dictionary["species"]["enumRef"] == "speciesEnum"
+    assert data_dictionary["species"]["description"] is None  # no fixed description; LLM fills it in
+    assert data_dictionary["count"]["type"] == "int"
+    assert data_dictionary["count"]["nullable"] is True
+
+    assert "canonicalSpecies" in base["canonical_enum_definitions"]
+    assert base["enum_definitions"]["speciesEnum"]["values"]["cattle"]["canonical"] == "cattle"
+
+
+def test_infer_deterministic_base_fills_fixed_structural_descriptions():
+    profile = CsvProfile(
+        path="fake.csv",
+        row_count=10,
+        columns=[
+            ColumnProfile(
+                name="state.ID", dtype="object", null_count=0, null_fraction=0.0,
+                distinct_count=2, sample_values=["state_KA"], all_distinct_values=["state_KA", "state_29"],
+            ),
+        ],
+        sample_rows_csv="state.ID\nstate_KA\n",
+    )
+
+    base = draft_service._infer_deterministic_base({"main": profile}, {"main": "fake.csv"})
+
+    field = base["tables"]["main"]["data_dictionary"]["state.ID"]
+    assert field["type"] == "regionID"
+    assert field["description"] == (
+        "LGD-based region identifier in the format state_<lgd_code> for states or "
+        "ut_<lgd_code> for union territories (e.g., state_28, ut_1)."
+    )
+
+
+def test_merge_narrative_into_base_overlays_descriptions_and_keeps_fixed_ones():
+    base = {
+        "tables": {
+            "main": {
+                "joinKeys": ["state.ID"],
+                "data_dictionary": {
+                    "state.ID": {"type": "regionID", "nullable": False, "description": "fixed description"},
+                    "count": {"type": "int", "nullable": True, "description": None},
+                },
+            }
+        },
+        "enum_definitions": {},
+        "canonical_enum_definitions": {},
+        "join_keys": ["state.ID"],
+        "region_gap_comments": ["[region history] Telangana was carved out of Andhra Pradesh."],
+    }
+    narrative = {
+        "datasetDescription": "A dataset.",
+        "comments": ["units are counts"],
+        "tables": {
+            "main": {
+                "description": "table narrative",
+                "source": "some source",
+                "data_dictionary": {
+                    "state.ID": {"description": "LLM should not override this"},
+                    "count": {"description": "Number of animals counted."},
+                },
+            }
+        },
+    }
+
+    merged = draft_service._merge_narrative_into_base(base, narrative)
+
+    assert merged["datasetDescription"] == "A dataset."
+    assert merged["joinKeys"] == ["state.ID"]
+    assert merged["comments"] == ["[region history] Telangana was carved out of Andhra Pradesh.", "units are counts"]
+    assert merged["tables"]["main"]["description"] == "table narrative"
+    assert merged["tables"]["main"]["source"] == "some source"
+    assert merged["tables"]["main"]["data_dictionary"]["state.ID"]["description"] == "fixed description"
+    assert merged["tables"]["main"]["data_dictionary"]["count"]["description"] == "Number of animals counted."
+
+
+def test_merge_narrative_into_base_falls_back_to_stub_when_llm_omits_a_description():
+    base = {
+        "tables": {"main": {"joinKeys": [], "data_dictionary": {"count": {"type": "int", "description": None}}}},
+        "enum_definitions": {},
+        "canonical_enum_definitions": {},
+        "join_keys": [],
+        "region_gap_comments": [],
+    }
+    narrative = {"tables": {"main": {"data_dictionary": {}}}}
+
+    merged = draft_service._merge_narrative_into_base(base, narrative)
+
+    assert merged["tables"]["main"]["data_dictionary"]["count"]["description"] == "'count' column."
+
+
+def test_merge_narrative_into_base_overlays_enum_definitions_preserving_canonical_matches():
+    base = {
+        "tables": {"main": {"joinKeys": [], "data_dictionary": {}}},
+        "enum_definitions": {
+            "speciesEnum": {
+                "description": "Values observed in the 'species' column.",
+                "values": {"cattle": {"description": "cattle", "canonical": "cattle", "canonicalRollup": "cattle"}},
+            }
+        },
+        "canonical_enum_definitions": {"canonicalSpecies": {"description": "x", "values": {}}},
+        "join_keys": [],
+        "region_gap_comments": [],
+    }
+    narrative = {
+        "enumDefinitions": {
+            "speciesEnum": {
+                "description": "Livestock species.",
+                "values": {"cattle": {"description": "Domestic cattle."}},
+            }
+        }
+    }
+
+    merged = draft_service._merge_narrative_into_base(base, narrative)
+
+    assert merged["enumDefinitions"]["speciesEnum"]["description"] == "Livestock species."
+    value = merged["enumDefinitions"]["speciesEnum"]["values"]["cattle"]
+    assert value["description"] == "Domestic cattle."
+    assert value["canonical"] == "cattle"  # deterministic linkage preserved through the merge
+    assert merged["canonicalEnumDefinitions"] == {"canonicalSpecies": {"description": "x", "values": {}}}
+
+
+def test_generate_draft_prompt_size_does_not_scale_with_row_count(monkeypatch):
+    """Reproduces the fix for the real production bug: a table with a huge
+    row_count (the actual cause of a ~2M-token prompt that blew past the
+    model's 1M-token cap) must not blow up prompt size anymore, since the
+    LLM is never shown raw row data - only the bounded profile summary
+    (sample_rows_csv is always <=20 rows, all_distinct_values is capped),
+    regardless of the file's real row count.
+    """
+    huge_profile = CsvProfile(
+        path="huge.csv", row_count=5_000_000, columns=[], missing_source_columns=[],
+        sample_rows_csv="a,b\n1,2\n" * 20,
+    )
+    monkeypatch.setattr(draft_service, "profile_csv", lambda path: huge_profile)
+    monkeypatch.setattr(draft_service, "load_digitization_log", lambda path: None)
+    monkeypatch.setattr(
+        draft_service, "_validate_manifest",
+        lambda manifest_dict, csv_path: ValidationResult(dataset_kind="tabular"),
+    )
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        lambda category_id: "CSRDS0099",
+    )
+    monkeypatch.setattr(draft_service, "get_collection_by_identifier", lambda collection_id: FAKE_COLLECTION)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+
+    captured_prompts = []
+
+    class RecordingClient:
+        model_id = "anthropic/claude-3.5-sonnet"
+
+        def __init__(self, *a, **kw):
+            pass
+
+        def complete(self, *, system_prompt, user_prompt):
+            captured_prompts.append(user_prompt)
+            return SimpleNamespace(text=LLM_RESPONSE, model=self.model_id, prompt_tokens=1, completion_tokens=1)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(draft_service, "OpenRouterDraftClient", RecordingClient)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", lambda **kwargs: SimpleNamespace(
+        draft_id="1", status=SimpleNamespace(value="pending"),
+        draft_yaml=kwargs["draft_yaml"], draft_json=kwargs["draft_json"], flagged_fields=kwargs["flagged_fields"],
+    ))
+
+    draft_service.generate_draft(
+        csv_paths=["foo.csv"], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD",
+    )
+
+    assert len(captured_prompts) == 1
+    # A 5M-row table's prompt must stay small (well under 50KB) - if this
+    # ever regresses back to embedding full CSV text, this assertion fails
+    # loudly instead of only surfacing as a real production 502.
+    assert len(captured_prompts[0]) < 50_000
 
 
 def test_generate_draft_raises_when_collection_does_not_exist(monkeypatch):

--- a/src/dataio/api/tests/test_draft_service.py
+++ b/src/dataio/api/tests/test_draft_service.py
@@ -290,6 +290,23 @@ def test_batch_tables_single_table_under_budget_is_one_batch():
     assert draft_service._batch_tables(["only"], context_sizes, char_budget=100) == [["only"]]
 
 
+def test_build_csv_paths_by_table_rejects_duplicate_filename_stems():
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        draft_service.build_csv_paths_by_table(["dir_a/data.csv", "dir_b/data.csv"])
+
+    assert exc_info.value.status_code == 400
+    assert "data" in exc_info.value.detail
+
+
+def test_build_csv_paths_by_table_allows_unique_stems():
+    result = draft_service.build_csv_paths_by_table(["dir_a/foo.csv", "dir_b/bar.csv"])
+
+    assert result == {"foo": "dir_a/foo.csv", "bar": "dir_b/bar.csv"}
+
+
 def test_merge_batch_manifests_single_batch_passes_through_unchanged():
     manifest = {"tables": {"main": {}}}
     flags = [{"field": "x", "reason": "y"}]

--- a/src/dataio/api/tests/test_draft_service.py
+++ b/src/dataio/api/tests/test_draft_service.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import os
+from datetime import date
+from types import SimpleNamespace
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from dataio.api.services import draft_service
+from dataio.api.services.csv_profiler import CsvProfile
+from dataio.validate.reports.models import ValidationResult
+
+LLM_RESPONSE = """---MANIFEST---
+datasetTitle: Foo Dataset
+datasetSlug: foo-dataset
+tables:
+  main:
+    description: table
+---FLAGS---
+flags:
+  - field: sourceTableID
+    reason: missing from CSV
+"""
+
+FAKE_COLLECTION = SimpleNamespace(
+    collection_id="CS0007", collection_name="Livestock Census (by DAHD)",
+    category_id="CS", category_name="Census and Surveys",
+)
+
+
+def _stub_csv_profile(missing_source_columns=None):
+    return CsvProfile(
+        path="foo.csv", row_count=5, columns=[], missing_source_columns=missing_source_columns or [],
+        sample_rows_csv="a,b\n1,2\n",
+    )
+
+
+class FakeOpenRouterClient:
+    model_id = "anthropic/claude-3.5-sonnet"
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def complete(self, *, system_prompt, user_prompt):
+        return SimpleNamespace(text=LLM_RESPONSE, model=self.model_id, prompt_tokens=10, completion_tokens=20)
+
+    def close(self):
+        pass
+
+
+def _patch_common(monkeypatch, missing_source_columns=None):
+    monkeypatch.setattr(draft_service, "profile_csv", lambda path: _stub_csv_profile(missing_source_columns))
+    monkeypatch.setattr(draft_service, "load_digitization_log", lambda path: None)
+    monkeypatch.setattr(draft_service, "read_full_csv_text", lambda path: "a,b\n1,2\n")
+    monkeypatch.setattr(draft_service, "OpenRouterDraftClient", FakeOpenRouterClient)
+    monkeypatch.setattr(
+        draft_service, "_validate_manifest",
+        lambda manifest_dict, csv_path: ValidationResult(dataset_kind="tabular"),
+    )
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        lambda category_id: "CSRDS0099",
+    )
+    monkeypatch.setattr(draft_service, "get_collection_by_identifier", lambda collection_id: FAKE_COLLECTION)
+
+
+def test_complete_with_retry_recovers_after_two_malformed_attempts():
+    """Reproduces a real production failure: the LLM's first attempt has an
+    unquoted colon inside a plain scalar ("mapping values are not allowed
+    here"), and the correction turn's response has the *same* class of bug
+    worded slightly differently - a single retry wasn't enough, so the loop
+    must keep going up to MAX_COMPLETION_ATTEMPTS rather than giving up
+    after one correction.
+    """
+    responses = iter([
+        '---MANIFEST---\ndescription: The source PDF (e.g. Table 15R: Buffaloes Male Rural), while old\n---FLAGS---\nflags: []\n',
+        '---MANIFEST---\ndescription: Another bad one: still has a colon\n---FLAGS---\nflags: []\n',
+        '---MANIFEST---\ndescription: "Finally quoted: correctly"\n---FLAGS---\nflags: []\n',
+    ])
+
+    class FlakyClient:
+        def complete(self, *, system_prompt, user_prompt):
+            return SimpleNamespace(text=next(responses))
+
+    manifest, flags = draft_service._complete_with_retry(FlakyClient(), "system", "user")
+    assert manifest["description"] == "Finally quoted: correctly"
+    assert flags == []
+
+
+def test_complete_with_retry_raises_last_error_after_exhausting_attempts():
+    class AlwaysBrokenClient:
+        def complete(self, *, system_prompt, user_prompt):
+            return SimpleNamespace(text="not the expected format at all")
+
+    import pytest
+    with pytest.raises(ValueError):
+        draft_service._complete_with_retry(AlwaysBrokenClient(), "system", "user")
+
+
+def test_generate_draft_happy_path(monkeypatch):
+    recorded = {}
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+
+    def fake_create_manifest_draft(**kwargs):
+        recorded["create_kwargs"] = kwargs
+        return SimpleNamespace(
+            draft_id="11111111-1111-1111-1111-111111111111",
+            status=SimpleNamespace(value="pending"),
+            draft_yaml=kwargs["draft_yaml"],
+            draft_json=kwargs["draft_json"],
+            flagged_fields=kwargs["flagged_fields"],
+        )
+
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", fake_create_manifest_draft)
+
+    result = draft_service.generate_draft(
+        csv_paths=["foo.csv"], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD",
+    )
+
+    assert result.status == "pending"
+    assert result.validation_status == "pass"
+    assert "raw_dataset" not in result.draft_json  # real metadata.yaml never has this field
+    assert recorded["create_kwargs"]["raw_dataset_id"] == "CSRDS0099"
+    assert result.draft_json["datasetID"] == "CS0007DS0999"
+    assert result.draft_json["datasetTitle"] == "foo"  # from the CSV filename, not the LLM
+    assert result.draft_json["datasetSlug"] == "cs0007ds0999-foo-dataset"
+    assert result.draft_json["metadataSpecVersion"] == "v2"
+    assert result.draft_json["category"] == {"ID": "CS", "name": "Census and Surveys"}
+    assert result.draft_json["collection"] == {"ID": "CS0007", "name": "Livestock Census (by DAHD)"}
+    assert result.draft_json["datasetOwner"] == "DAHD"
+    assert result.draft_json["lastUpdated"] == date.today().isoformat()
+    # canonical key order: datasetTitle first, tables last
+    assert list(result.draft_json.keys())[0] == "datasetTitle"
+    assert list(result.draft_json.keys())[-1] == "tables"
+    assert recorded["create_kwargs"]["dataset_id"] == "CS0007DS0999"
+    assert recorded["create_kwargs"]["flagged_fields"] == [{"field": "sourceTableID", "reason": "missing from CSV"}]
+    assert recorded["create_kwargs"]["source_csv_path"] == '{"foo": "foo.csv"}'
+
+
+def test_generate_draft_with_multiple_csvs_builds_one_table_per_csv(monkeypatch):
+    """Multiple CSVs uploaded for one draft each become their own table
+    (named after that CSV's filename stem), matching the real multi-table
+    convention used by e.g. CS0026DS0111 (bahs-milk-production-statistics).
+    """
+    recorded = {}
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+
+    def fake_create_manifest_draft(**kwargs):
+        recorded["create_kwargs"] = kwargs
+        return SimpleNamespace(
+            draft_id="11111111-1111-1111-1111-111111111111",
+            status=SimpleNamespace(value="pending"),
+            draft_yaml=kwargs["draft_yaml"],
+            draft_json=kwargs["draft_json"],
+            flagged_fields=kwargs["flagged_fields"],
+        )
+
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", fake_create_manifest_draft)
+
+    result = draft_service.generate_draft(
+        csv_paths=["foo.csv", "bar.csv"], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+    )
+
+    # with more than one table there's no single filename to default to, so
+    # the LLM's own proposed datasetTitle (from LLM_RESPONSE) is used as-is
+    assert result.draft_json["datasetTitle"] == "Foo Dataset"
+    assert recorded["create_kwargs"]["source_csv_path"] == '{"foo": "foo.csv", "bar": "bar.csv"}'
+
+
+def test_generate_draft_reuses_existing_dataset_id_without_reserving(monkeypatch):
+    _patch_common(monkeypatch)
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("should not mint/reserve a new ID when one was already supplied")
+
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", fail_if_called)
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", fail_if_called)
+    # dataset_id is reused below, but raw_dataset_id is not supplied, so rds_id
+    # resolution/reservation still runs - a separate axis from dataset_id reuse.
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", lambda **kwargs: SimpleNamespace(
+        draft_id="1", status=SimpleNamespace(value="pending"),
+        draft_yaml=kwargs["draft_yaml"], draft_json=kwargs["draft_json"], flagged_fields=kwargs["flagged_fields"],
+    ))
+
+    result = draft_service.generate_draft(
+        csv_paths=["foo.csv"], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", dataset_id="CS0007DS0112",
+    )
+
+    assert result.draft_json["datasetID"] == "CS0007DS0112"
+    assert result.draft_json["datasetSlug"] == "cs0007ds0112-foo-dataset"
+
+
+def test_generate_draft_reuses_existing_raw_dataset_id_without_reserving(monkeypatch):
+    """regenerate_draft passes the original draft's raw_dataset_id through,
+    so a redraft of the same dataset doesn't reserve (and leak) a second one.
+    """
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("should not mint/reserve a new rds_id when one was already supplied")
+
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category", fail_if_called
+    )
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", fail_if_called)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", lambda **kwargs: SimpleNamespace(
+        draft_id="1", status=SimpleNamespace(value="pending"),
+        draft_yaml=kwargs["draft_yaml"], draft_json=kwargs["draft_json"], flagged_fields=kwargs["flagged_fields"],
+    ))
+
+    draft_service.generate_draft(
+        csv_paths=["foo.csv"], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD", raw_dataset_id="CSRDS0016",
+    )
+
+
+def test_generate_draft_flags_missing_source_columns(monkeypatch):
+    _patch_common(monkeypatch, missing_source_columns=["sourceTableID", "sourcePage"])
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+
+    captured = {}
+
+    def fake_create_manifest_draft(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            draft_id="11111111-1111-1111-1111-111111111111",
+            status=SimpleNamespace(value="pending"),
+            draft_yaml=kwargs["draft_yaml"],
+            draft_json=kwargs["draft_json"],
+            flagged_fields=kwargs["flagged_fields"],
+        )
+
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", fake_create_manifest_draft)
+
+    draft_service.generate_draft(
+        csv_paths=["foo.csv"], category_id="CS", collection_id="CS0007", created_by="engineer@artpark.in",
+        data_owner_name="DAHD",
+    )
+
+    # sourceTableID was already flagged by the LLM (kept, not duplicated);
+    # sourcePage wasn't, so the deterministic safety net adds it even though
+    # the LLM didn't
+    fields_flagged = {f["field"] for f in captured["flagged_fields"]}
+    assert fields_flagged == {"sourceTableID", "sourcePage"}
+    source_table_flags = [f for f in captured["flagged_fields"] if f["field"] == "sourceTableID"]
+    assert len(source_table_flags) == 1
+    assert source_table_flags[0]["reason"] == "missing from CSV"
+
+
+def test_batch_tables_groups_by_cumulative_size():
+    full_csv_texts = {"a": "x" * 40, "b": "x" * 40, "c": "x" * 40}
+
+    batches = draft_service._batch_tables(["a", "b", "c"], full_csv_texts, char_budget=100)
+
+    # a+b = 80 (fits), c alone starts a new batch (80 + 40 > 100)
+    assert batches == [["a", "b"], ["c"]]
+
+
+def test_batch_tables_puts_oversized_single_table_in_its_own_batch():
+    full_csv_texts = {"huge": "x" * 500, "small": "x" * 10}
+
+    batches = draft_service._batch_tables(["huge", "small"], full_csv_texts, char_budget=100)
+
+    # "huge" alone already exceeds the budget, but is never dropped/split -
+    # it still gets its own solo batch with its full content intact.
+    assert batches == [["huge"], ["small"]]
+
+
+def test_batch_tables_single_table_under_budget_is_one_batch():
+    full_csv_texts = {"only": "x" * 10}
+
+    assert draft_service._batch_tables(["only"], full_csv_texts, char_budget=100) == [["only"]]
+
+
+def test_merge_batch_manifests_single_batch_passes_through_unchanged():
+    manifest = {"tables": {"main": {}}}
+    flags = [{"field": "x", "reason": "y"}]
+
+    result = draft_service._merge_batch_manifests([(manifest, flags)])
+
+    assert result == (manifest, flags)
+
+
+def test_merge_batch_manifests_combines_disjoint_tables_and_concatenates_flags():
+    batch_results = [
+        ({"tables": {"foo": {"description": "foo table"}}}, [{"field": "foo_col", "reason": "r1"}]),
+        ({"tables": {"bar": {"description": "bar table"}}}, [{"field": "bar_col", "reason": "r2"}]),
+    ]
+
+    manifest, flags = draft_service._merge_batch_manifests(batch_results)
+
+    assert manifest["tables"] == {
+        "foo": {"description": "foo table"},
+        "bar": {"description": "bar table"},
+    }
+    assert flags == [{"field": "foo_col", "reason": "r1"}, {"field": "bar_col", "reason": "r2"}]
+
+
+def test_merge_batch_manifests_takes_single_source_fields_from_first_batch_only():
+    batch_results = [
+        ({"tables": {}, "datasetDescription": "the real description"}, []),
+        ({"tables": {}, "datasetDescription": "a second call must not override this"}, []),
+    ]
+
+    manifest, _ = draft_service._merge_batch_manifests(batch_results)
+
+    assert manifest["datasetDescription"] == "the real description"
+
+
+def test_merge_batch_manifests_unions_list_fields_without_duplicates():
+    batch_results = [
+        ({"tables": {}, "joinKeys": ["state.ID", "year"], "comments": ["shared fact"]}, []),
+        ({"tables": {}, "joinKeys": ["year", "species"], "comments": ["shared fact", "second-batch fact"]}, []),
+    ]
+
+    manifest, _ = draft_service._merge_batch_manifests(batch_results)
+
+    assert manifest["joinKeys"] == ["state.ID", "year", "species"]
+    assert manifest["comments"] == ["shared fact", "second-batch fact"]
+
+
+def test_merge_batch_manifests_unions_tags_and_enum_definitions():
+    batch_results = [
+        (
+            {
+                "tables": {},
+                "tags": {"concept": ["livestock"], "epiType": ["population"]},
+                "enumDefinitions": {"species": {"description": "d1", "values": {}}},
+            },
+            [],
+        ),
+        (
+            {
+                "tables": {},
+                "tags": {"concept": ["livestock", "milk"], "epiType": []},
+                "enumDefinitions": {"breed": {"description": "d2", "values": {}}},
+            },
+            [],
+        ),
+    ]
+
+    manifest, _ = draft_service._merge_batch_manifests(batch_results)
+
+    assert manifest["tags"] == {"concept": ["livestock", "milk"], "epiType": ["population"]}
+    assert set(manifest["enumDefinitions"].keys()) == {"species", "breed"}
+
+
+def test_generate_draft_splits_dataset_into_multiple_batches_when_over_char_budget(monkeypatch):
+    """A dataset whose combined full-CSV-text exceeds BATCH_CHAR_BUDGET must
+    be drafted over multiple LLM calls (one per table here, given the tiny
+    monkeypatched budget) rather than one oversized call - and the batches'
+    results must be merged into one manifest.
+    """
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "BATCH_CHAR_BUDGET", 10)
+    monkeypatch.setattr(draft_service, "read_full_csv_text", lambda path: "x" * 20)
+
+    calls = []
+
+    class FakeBatchClient:
+        model_id = "anthropic/claude-sonnet-5"
+
+        def __init__(self, *a, **kw):
+            pass
+
+        def complete(self, *, system_prompt, user_prompt):
+            index = len(calls)
+            calls.append(user_prompt)
+            table_name = ["foo", "bar", "baz"][index]
+            dataset_fields = "datasetDescription: shared description\n" if index == 0 else ""
+            text = (
+                "---MANIFEST---\n"
+                f"{dataset_fields}"
+                "tables:\n"
+                f"  {table_name}:\n"
+                "    description: table\n"
+                "---FLAGS---\n"
+                "flags:\n"
+                f"  - field: {table_name}_col\n"
+                f"    reason: flagged in batch {index}\n"
+            )
+            return SimpleNamespace(text=text, model=self.model_id, prompt_tokens=1, completion_tokens=1)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(draft_service, "OpenRouterDraftClient", FakeBatchClient)
+    monkeypatch.setattr(draft_service.database, "create_manifest_draft", lambda **kwargs: SimpleNamespace(
+        draft_id="1", status=SimpleNamespace(value="pending"),
+        draft_yaml=kwargs["draft_yaml"], draft_json=kwargs["draft_json"], flagged_fields=kwargs["flagged_fields"],
+    ))
+
+    result = draft_service.generate_draft(
+        csv_paths=["foo.csv", "bar.csv", "baz.csv"], category_id="CS", collection_id="CS0007",
+        created_by="engineer@artpark.in", data_owner_name="DAHD",
+    )
+
+    assert len(calls) == 3  # one LLM call per table, since each table alone exceeds the tiny budget
+    assert set(result.draft_json["tables"].keys()) == {"foo", "bar", "baz"}
+    assert result.draft_json["datasetDescription"] == "shared description"  # only the first batch supplied it
+    assert {f["field"] for f in result.flagged_fields} == {"foo_col", "bar_col", "baz_col"}
+
+
+def test_generate_draft_raises_when_collection_does_not_exist(monkeypatch):
+    from fastapi import HTTPException
+
+    import pytest
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(draft_service, "get_collection_by_identifier", lambda collection_id: None)
+    monkeypatch.setattr(draft_service, "suggest_next_dataset_id", lambda collection_id: "CS0007DS0999")
+    monkeypatch.setattr(draft_service, "create_reserved_dataset_id", lambda *a, **kw: None)
+    monkeypatch.setattr(draft_service, "create_reserved_raw_dataset_id", lambda *a, **kw: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        draft_service.generate_draft(
+            csv_paths=["foo.csv"], category_id="CS", collection_id="CS9999", created_by="engineer@artpark.in",
+            data_owner_name="DAHD",
+        )
+    assert exc_info.value.status_code == 400

--- a/src/dataio/api/tests/test_draft_service_dataset_id.py
+++ b/src/dataio/api/tests/test_draft_service_dataset_id.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataio.api.services.draft_service import (
+    _build_dataset_slug,
+    _resolve_and_reserve_raw_dataset_id,
+    _resolve_dataset_id,
+)
+
+
+def test_build_dataset_slug_uses_llm_provided_words():
+    assert _build_dataset_slug("CS0007DS0113", "consolidated-livestock-census", "ignored") == (
+        "cs0007ds0113-consolidated-livestock-census"
+    )
+
+
+def test_build_dataset_slug_strips_llm_guessed_id_prefix():
+    # The LLM was told not to prefix the slug with an ID, but if it does
+    # anyway (possibly guessing wrong), the real one must still win.
+    assert _build_dataset_slug("CS0007DS0113", "cs0001ds0099-consolidated-census", "ignored") == (
+        "cs0007ds0113-consolidated-census"
+    )
+
+
+def test_build_dataset_slug_falls_back_to_title_when_slug_missing():
+    assert _build_dataset_slug("CS0007DS0113", None, "Consolidated Livestock Census!") == (
+        "cs0007ds0113-consolidated-livestock-census"
+    )
+
+
+def test_build_dataset_slug_falls_back_to_dataset_when_nothing_usable():
+    assert _build_dataset_slug("CS0007DS0113", "", "") == "cs0007ds0113-dataset"
+
+
+def test_resolve_dataset_id_returns_existing_id_unchanged(monkeypatch):
+    def fail_if_called(*a, **kw):
+        raise AssertionError("should not mint a new ID when one was already supplied")
+
+    monkeypatch.setattr("dataio.api.services.draft_service.suggest_next_dataset_id", fail_if_called)
+    monkeypatch.setattr("dataio.api.services.draft_service.create_reserved_dataset_id", fail_if_called)
+
+    assert _resolve_dataset_id("CS0007DS0112", "CS0007", "engineer@artpark.in") == "CS0007DS0112"
+
+
+def test_resolve_dataset_id_mints_and_reserves_when_none_given(monkeypatch):
+    recorded = {}
+
+    monkeypatch.setattr(
+        "dataio.api.services.draft_service.suggest_next_dataset_id",
+        lambda collection_id: "CS0007DS0999",
+    )
+
+    def fake_reserve(ds_id, collection_id, note, reserved_by):
+        recorded.update(ds_id=ds_id, collection_id=collection_id, note=note, reserved_by=reserved_by)
+
+    monkeypatch.setattr("dataio.api.services.draft_service.create_reserved_dataset_id", fake_reserve)
+
+    result = _resolve_dataset_id(None, "CS0007", "engineer@artpark.in")
+
+    assert result == "CS0007DS0999"
+    assert recorded["ds_id"] == "CS0007DS0999"
+    assert recorded["collection_id"] == "CS0007"
+    assert recorded["reserved_by"] == "engineer@artpark.in"
+
+
+def test_resolve_and_reserve_raw_dataset_id_returns_existing_id_unchanged(monkeypatch):
+    def fail_if_called(*a, **kw):
+        raise AssertionError("should not mint a new rds_id when one was already supplied")
+
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        fail_if_called,
+    )
+    monkeypatch.setattr(
+        "dataio.api.services.draft_service.create_reserved_raw_dataset_id",
+        fail_if_called,
+    )
+
+    result = _resolve_and_reserve_raw_dataset_id("CSRDS0016", "CS", "CS0007", "engineer@artpark.in")
+    assert result == "CSRDS0016"
+
+
+def test_resolve_and_reserve_raw_dataset_id_mints_and_reserves_when_none_given(monkeypatch):
+    recorded = {}
+
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        lambda category_id: "CSRDS0099",
+    )
+
+    def fake_reserve(rds_id, category_id, note, reserved_by):
+        recorded.update(rds_id=rds_id, category_id=category_id, note=note, reserved_by=reserved_by)
+
+    monkeypatch.setattr(
+        "dataio.api.services.draft_service.create_reserved_raw_dataset_id",
+        fake_reserve,
+    )
+
+    result = _resolve_and_reserve_raw_dataset_id(None, "CS", "CS0007", "engineer@artpark.in")
+
+    assert result == "CSRDS0099"
+    assert recorded["rds_id"] == "CSRDS0099"
+    assert recorded["category_id"] == "CS"
+    assert recorded["reserved_by"] == "engineer@artpark.in"

--- a/src/dataio/api/tests/test_draft_upload_storage.py
+++ b/src/dataio/api/tests/test_draft_upload_storage.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from fastapi import UploadFile
+
+from dataio.api.services import draft_upload_storage
+
+
+def test_save_upload_writes_file_and_returns_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    upload = UploadFile(filename="data.csv", file=io.BytesIO(b"a,b\n1,2\n"))
+    saved_path = draft_upload_storage.save_upload(upload)
+
+    assert saved_path.endswith("data.csv")
+    with open(saved_path, "rb") as f:
+        assert f.read() == b"a,b\n1,2\n"
+
+
+def test_save_upload_is_collision_proof(tmp_path, monkeypatch):
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    upload_a = UploadFile(filename="data.csv", file=io.BytesIO(b"first"))
+    upload_b = UploadFile(filename="data.csv", file=io.BytesIO(b"second"))
+
+    path_a = draft_upload_storage.save_upload(upload_a)
+    path_b = draft_upload_storage.save_upload(upload_b)
+
+    assert path_a != path_b
+    with open(path_a, "rb") as f:
+        assert f.read() == b"first"
+    with open(path_b, "rb") as f:
+        assert f.read() == b"second"
+
+
+def test_save_upload_rejects_path_traversal_in_filename(tmp_path, monkeypatch):
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    upload = UploadFile(filename="../../etc/evil.csv", file=io.BytesIO(b"malicious"))
+    saved_path = draft_upload_storage.save_upload(upload)
+
+    saved = Path(saved_path).resolve()
+    assert saved.is_relative_to(tmp_path.resolve())
+    assert saved.name == "evil.csv"
+
+
+def test_save_upload_rejects_absolute_path_filename(tmp_path, monkeypatch):
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    absolute_target = tmp_path.parent / "outside.csv"
+    upload = UploadFile(filename=str(absolute_target), file=io.BytesIO(b"malicious"))
+    saved_path = draft_upload_storage.save_upload(upload)
+
+    saved = Path(saved_path).resolve()
+    assert saved.is_relative_to(tmp_path.resolve())
+    assert not absolute_target.exists()

--- a/src/dataio/api/tests/test_field_inference.py
+++ b/src/dataio/api/tests/test_field_inference.py
@@ -10,6 +10,9 @@ from dataio.api.services.field_inference import (
     infer_join_key_candidates,
     lookup_canonical_enum_definitions,
     match_canonical_values,
+    suggest_spatial_coverage,
+    suggest_spatial_resolution,
+    suggest_temporal_coverage,
 )
 
 
@@ -334,3 +337,52 @@ def test_match_canonical_values_defaults_rollup_to_own_key_when_no_rollup_field(
     result = match_canonical_values(["indigenous"], canonical_definition)
 
     assert result["indigenous"] == {"canonical": "indigenous", "canonicalRollup": "indigenous"}
+
+
+def test_suggest_spatial_coverage_is_india_for_state_region_column():
+    data_dictionary = {"state.name": {"type": "regionName"}, "count": {"type": "int"}}
+
+    assert suggest_spatial_coverage(data_dictionary) == "India"
+
+
+def test_suggest_spatial_coverage_none_without_state_or_ut_column():
+    data_dictionary = {"district.name": {"type": "regionName"}, "count": {"type": "int"}}
+
+    assert suggest_spatial_coverage(data_dictionary) is None
+
+
+def test_suggest_spatial_resolution_picks_finest_grain_present():
+    data_dictionary = {
+        "state.name": {"type": "regionName"},
+        "district.name": {"type": "regionName"},
+        "count": {"type": "int"},
+    }
+
+    assert suggest_spatial_resolution(data_dictionary) == "district"
+
+
+def test_suggest_spatial_resolution_none_without_region_name_column():
+    data_dictionary = {"state.ID": {"type": "regionID"}, "count": {"type": "int"}}
+
+    assert suggest_spatial_resolution(data_dictionary) is None
+
+
+def test_suggest_spatial_resolution_unrecognized_prefix_still_returned():
+    data_dictionary = {"block.name": {"type": "regionName"}}
+
+    assert suggest_spatial_resolution(data_dictionary) == "block"
+
+
+def test_suggest_temporal_coverage_joins_observed_years():
+    data_dictionary = {
+        "year": {"type": "date", "format": "%Y", "allowedValues": ["1997", "2003", "2019"]},
+        "count": {"type": "int"},
+    }
+
+    assert suggest_temporal_coverage(data_dictionary) == "1997, 2003, 2019"
+
+
+def test_suggest_temporal_coverage_none_without_year_column():
+    data_dictionary = {"count": {"type": "int"}}
+
+    assert suggest_temporal_coverage(data_dictionary) is None

--- a/src/dataio/api/tests/test_field_inference.py
+++ b/src/dataio/api/tests/test_field_inference.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from dataio.api.services.csv_profiler import ColumnProfile, CsvProfile
+from dataio.api.services.field_inference import (
+    apply_join_keys,
+    find_region_lgd_pairs,
+    infer_column_type,
+    infer_data_dictionary,
+    infer_fixed_column_description,
+    infer_join_key_candidates,
+    lookup_canonical_enum_definitions,
+    match_canonical_values,
+)
+
+
+def _column(name, *, dtype="object", null_count=0, distinct_count=2, all_distinct_values=None, row_count=10):
+    return ColumnProfile(
+        name=name, dtype=dtype, null_count=null_count, null_fraction=(null_count / row_count) if row_count else 0.0,
+        distinct_count=distinct_count, sample_values=(all_distinct_values or [])[:5],
+        all_distinct_values=all_distinct_values,
+    )
+
+
+def _profile(columns, row_count=10):
+    return CsvProfile(path="x.csv", row_count=row_count, columns=columns, sample_rows_csv="")
+
+
+def test_infer_column_type_bare_year_column_is_date():
+    column = _column("year", dtype="int64", all_distinct_values=["2019", "2020"])
+    field = infer_column_type(column)
+    assert field == {
+        "type": "date", "format": "%Y", "nullable": False,
+        "allowedValues": ["2019", "2020"], "temporal_axis": "year",
+    }
+
+
+def test_infer_column_type_all_values_four_digit_is_date_even_without_year_name():
+    column = _column("survey.year", all_distinct_values=["1997", "2003", "2019"])
+    assert infer_column_type(column)["type"] == "date"
+
+
+def test_infer_column_type_year_column_gets_allowed_values_and_temporal_axis():
+    column = _column("year", dtype="int64", all_distinct_values=["1997", "2003", "2019"])
+    field = infer_column_type(column)
+    assert field["allowedValues"] == ["1997", "2003", "2019"]
+    assert field["temporal_axis"] == "year"
+
+
+def test_infer_column_type_low_cardinality_numeric_column_stays_int_not_enum():
+    # Regression: a numeric-dtype column with a small closed set of values
+    # (e.g. a real "sourcePage" page-number column with ~150 distinct
+    # values) must stay int, not become a bloated enum of every number seen
+    # - "enum" is for closed sets of text categories, not numeric ranges.
+    values = [str(n) for n in range(1, 50)]
+    column = _column("sourcePage", dtype="int64", all_distinct_values=values)
+    assert infer_column_type(column)["type"] == "int"
+
+
+def test_infer_column_type_region_id_shaped_values():
+    column = _column("state.ID", all_distinct_values=["state_KA", "state_TG"])
+    field = infer_column_type(column)
+    assert field["type"] == "regionID"
+
+
+def test_infer_column_type_id_column_not_region_shaped_falls_through():
+    # A plain numeric/freeform ".ID" column (e.g. a row primary key) must
+    # NOT be typed regionID just because of the suffix.
+    column = _column("record.ID", dtype="int64", all_distinct_values=["1", "2", "3"])
+    field = infer_column_type(column)
+    assert field["type"] != "regionID"
+
+
+def test_infer_column_type_name_column_is_region_name():
+    column = _column("state.name", all_distinct_values=["Karnataka", "Telangana"])
+    assert infer_column_type(column)["type"] == "regionName"
+
+
+def test_infer_column_type_lgd_code_column_is_int():
+    column = _column("state.lgd_code", dtype="int64", all_distinct_values=["29", "36"])
+    assert infer_column_type(column)["type"] == "int"
+
+
+def test_infer_column_type_low_cardinality_becomes_enum_with_ref_name():
+    column = _column("species", all_distinct_values=["cattle", "buffalo"])
+    field = infer_column_type(column)
+    assert field["type"] == "enum"
+    assert field["enumRef"] == "speciesEnum"
+
+
+def test_infer_column_type_enum_ref_name_camel_cases_dotted_and_underscored_names():
+    column = _column("table.source_document", all_distinct_values=["a", "b"])
+    field = infer_column_type(column)
+    assert field["enumRef"] == "sourceDocumentEnum"
+
+
+def test_infer_column_type_enum_ref_name_preserves_already_camel_case_names():
+    # Regression: a column already in camelCase (e.g. the real
+    # "sourceDocument"/"sourceTableID" columns in the live livestock census
+    # CSVs) must round-trip unchanged, not collapse into one lowercased
+    # token ("sourcedocumentEnum").
+    assert infer_column_type(_column("sourceDocument", all_distinct_values=["a", "b"]))["enumRef"] == (
+        "sourceDocumentEnum"
+    )
+    assert infer_column_type(_column("sourceTableID", all_distinct_values=["a", "b"]))["enumRef"] == (
+        "sourceTableIDEnum"
+    )
+
+
+def test_infer_column_type_high_cardinality_numeric_is_int_or_float():
+    int_column = _column("count", dtype="int64", distinct_count=500, all_distinct_values=None)
+    float_column = _column("rate", dtype="float64", distinct_count=500, all_distinct_values=None)
+    assert infer_column_type(int_column)["type"] == "int"
+    assert infer_column_type(float_column)["type"] == "float"
+
+
+def test_infer_column_type_high_cardinality_text_is_string():
+    column = _column("free_text_notes", dtype="object", distinct_count=500, all_distinct_values=None)
+    assert infer_column_type(column)["type"] == "string"
+
+
+def test_infer_column_type_nullable_reflects_null_fraction():
+    non_nullable = _column("state.ID", all_distinct_values=["state_KA"], null_count=0)
+    nullable = _column("state.ID", all_distinct_values=["state_KA"], null_count=2)
+    assert infer_column_type(non_nullable)["nullable"] is False
+    assert infer_column_type(nullable)["nullable"] is True
+
+
+def test_infer_data_dictionary_builds_enum_definitions_for_enum_columns():
+    profile = _profile([
+        _column("species", all_distinct_values=["cattle", "buffalo"]),
+        _column("count", dtype="int64", distinct_count=500, all_distinct_values=None),
+    ])
+    data_dictionary, enum_definitions = infer_data_dictionary(profile)
+
+    assert set(data_dictionary.keys()) == {"species", "count"}
+    assert data_dictionary["species"]["type"] == "enum"
+    assert "speciesEnum" in enum_definitions
+    assert enum_definitions["speciesEnum"]["values"] == {
+        "cattle": {"description": "cattle"}, "buffalo": {"description": "buffalo"},
+    }
+    assert data_dictionary["count"]["type"] == "int"  # high-cardinality column never became an enum
+
+
+def test_find_region_lgd_pairs_only_pairs_when_lgd_sibling_exists():
+    profile = _profile([
+        _column("state.ID", all_distinct_values=["state_KA", "state_TG"]),
+        _column("state.lgd_code", dtype="int64", all_distinct_values=["29", "36"]),
+        _column("district.ID", all_distinct_values=["district_A"]),  # no district.lgd_code sibling
+    ])
+    data_dictionary, _ = infer_data_dictionary(profile)
+
+    pairs = find_region_lgd_pairs(profile, data_dictionary)
+
+    assert pairs == [("state.ID", "state.lgd_code")]
+
+
+def test_find_region_lgd_pairs_ignores_id_columns_not_typed_region_id():
+    profile = _profile([
+        _column("record.ID", dtype="int64", all_distinct_values=["1", "2"]),
+        _column("record.lgd_code", dtype="int64", all_distinct_values=["1", "2"]),
+    ])
+    data_dictionary, _ = infer_data_dictionary(profile)
+
+    assert find_region_lgd_pairs(profile, data_dictionary) == []
+
+
+def test_infer_join_key_candidates_combines_region_lgd_pairs_and_date_columns():
+    profile = _profile([
+        _column("state.ID", all_distinct_values=["state_KA", "state_TG"]),
+        _column("state.lgd_code", dtype="int64", all_distinct_values=["29", "36"]),
+        _column("year", dtype="int64", all_distinct_values=["2019", "2020"]),
+        _column("count", dtype="int64", distinct_count=500, all_distinct_values=None),
+    ])
+    data_dictionary, _ = infer_data_dictionary(profile)
+
+    candidates = infer_join_key_candidates(profile, data_dictionary)
+
+    assert candidates == ["state.lgd_code", "state.ID", "year"]
+
+
+def test_infer_join_key_candidates_excludes_source_provenance_year_columns():
+    # Regression: "sourcepdf.year" (real column in the BAHS milk/meat CSVs)
+    # records the source PDF's own publish year - constant per document, not
+    # a dimension of the data - and must not be suggested as a join key just
+    # because its bare name is "year".
+    profile = _profile([
+        _column("year", dtype="int64", all_distinct_values=["2019", "2020"]),
+        _column("sourcepdf.year", dtype="int64", all_distinct_values=["2006"]),
+    ])
+    data_dictionary, _ = infer_data_dictionary(profile)
+
+    candidates = infer_join_key_candidates(profile, data_dictionary)
+
+    assert candidates == ["year"]
+
+
+def test_apply_join_keys_marks_temporal_vs_composite_component():
+    data_dictionary = {
+        "year": {"type": "date", "format": "%Y", "nullable": False},
+        "state.ID": {"type": "regionID", "nullable": False},
+    }
+
+    apply_join_keys(data_dictionary, ["year", "state.ID"])
+
+    assert data_dictionary["year"]["isJoinKey"] is True
+    assert data_dictionary["year"]["joinKeyType"] == "temporal"
+    assert data_dictionary["state.ID"]["isJoinKey"] is True
+    assert data_dictionary["state.ID"]["joinKeyType"] == "compositeComponent"
+
+
+def test_apply_join_keys_ignores_unknown_column_names():
+    data_dictionary = {"year": {"type": "date", "nullable": False}}
+    # must not raise even if a candidate name isn't actually in the dict
+    apply_join_keys(data_dictionary, ["year", "does_not_exist"])
+    assert "does_not_exist" not in data_dictionary
+
+
+def test_lookup_canonical_enum_definitions_matches_species_column():
+    result = lookup_canonical_enum_definitions(["species"])
+
+    assert "canonicalSpecies" in result
+    assert "canonicalBreed" not in result
+    assert result["canonicalSpecies"]["values"]["bovine"] == {"grain": "group", "components": ["cattle", "buffalo"]}
+
+
+def test_lookup_canonical_enum_definitions_matches_breed_column_by_bare_name():
+    result = lookup_canonical_enum_definitions(["cattle.breed"])
+
+    assert "canonicalBreed" in result
+    assert "canonicalSpecies" not in result
+
+
+def test_lookup_canonical_enum_definitions_returns_empty_for_unrelated_columns():
+    assert lookup_canonical_enum_definitions(["state.name", "year", "count"]) == {}
+
+
+def test_infer_fixed_column_description_region_id_uses_prefix():
+    # A prefix with no hardcoded text (e.g. "block") still uses the generic template.
+    assert infer_fixed_column_description("block.ID") == "Prefixed LGD identifier for the block."
+
+
+def test_infer_fixed_column_description_region_name_uses_prefix():
+    assert infer_fixed_column_description("block.name") == (
+        "Block name standardised to LGD classification."
+    )
+
+
+def test_infer_fixed_column_description_lgd_code_references_sibling_id():
+    assert infer_fixed_column_description("block.lgd_code") == (
+        "Numeric LGD code extracted from block.ID."
+    )
+
+
+def test_infer_fixed_column_description_district_trio_uses_hardcoded_text():
+    assert infer_fixed_column_description("district.ID") == "LGD district code."
+    assert infer_fixed_column_description("district.lgd_code") == (
+        "Numeric LGD district code extracted from district.ID."
+    )
+    assert infer_fixed_column_description("district.name") == "District name as per LGD."
+
+
+def test_infer_fixed_column_description_state_trio_uses_hardcoded_text():
+    # state.ID/state.lgd_code/state.name are hardcoded (not the generic
+    # <prefix>-templated text) since "state" is the overwhelmingly common
+    # region-identifier prefix across real datasets.
+    assert infer_fixed_column_description("state.ID") == (
+        "LGD-based region identifier in the format state_<lgd_code> for states or "
+        "ut_<lgd_code> for union territories (e.g., state_28, ut_1)."
+    )
+    assert infer_fixed_column_description("state.lgd_code") == (
+        "Standard numeric Local Government Directory (LGD) code for the state or union territory."
+    )
+    assert infer_fixed_column_description("state.name") == (
+        "State or union territory name in title case as per LGD."
+    )
+
+
+def test_infer_fixed_column_description_known_source_columns():
+    assert infer_fixed_column_description("sourceDocument") is not None
+    assert infer_fixed_column_description("sourceTableID") is not None
+    assert infer_fixed_column_description("sourcePage") is not None
+    assert infer_fixed_column_description("sourcePDFPage") is not None
+    assert infer_fixed_column_description("sourceSheetRef") is not None
+    assert infer_fixed_column_description("sourceGranularity") is not None
+
+
+def test_infer_fixed_column_description_unknown_source_column_gets_generic_fallback():
+    assert infer_fixed_column_description("sourceWeirdNewField") == (
+        "Provenance metadata: sourceWeirdNewField."
+    )
+
+
+def test_infer_fixed_column_description_returns_none_for_domain_columns():
+    assert infer_fixed_column_description("species") is None
+    assert infer_fixed_column_description("count") is None
+    assert infer_fixed_column_description("year") is None
+
+
+def test_infer_join_key_candidates_includes_enum_dimension_columns():
+    profile = _profile([
+        _column("year", dtype="int64", all_distinct_values=["2019", "2020"]),
+        _column("species", all_distinct_values=["cattle", "buffalo"]),
+        _column("sourceDocument", all_distinct_values=["a.pdf", "b.pdf"]),
+    ])
+    data_dictionary, _ = infer_data_dictionary(profile)
+
+    candidates = infer_join_key_candidates(profile, data_dictionary)
+
+    assert candidates == ["year", "species"]  # sourceDocument (provenance) excluded
+
+
+def test_match_canonical_values_matches_normalized_keys_and_carries_rollup():
+    canonical_definition = {
+        "values": {
+            "crossbred_exotic": {"grain": "coarse", "components": ["exotic", "crossbred"]},
+            "exotic": {"grain": "leaf", "rollup": "crossbred_exotic"},
+            "indigenous": {"grain": "leaf"},
+        }
+    }
+
+    values = ["crossbred/exotic", "exotic", "unmatched value"]
+    result = match_canonical_values(values, canonical_definition)
+
+    assert result["crossbred/exotic"] == {
+        "canonical": "crossbred_exotic", "canonicalRollup": "crossbred_exotic",
+    }
+    assert result["exotic"] == {"canonical": "exotic", "canonicalRollup": "crossbred_exotic"}
+    assert "unmatched value" not in result
+
+
+def test_match_canonical_values_defaults_rollup_to_own_key_when_no_rollup_field():
+    canonical_definition = {"values": {"indigenous": {"grain": "leaf"}}}
+
+    result = match_canonical_values(["indigenous"], canonical_definition)
+
+    assert result["indigenous"] == {"canonical": "indigenous", "canonicalRollup": "indigenous"}

--- a/src/dataio/api/tests/test_import_dataset_from_draft.py
+++ b/src/dataio/api/tests/test_import_dataset_from_draft.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+import pytest
+from fastapi import HTTPException
+
+from dataio.api.database.enums import VersionType
+from dataio.api.services.web_admin_service import WebAdminService
+
+ADMIN_USER = SimpleNamespace(email="admin@example.com", is_admin=True, is_group=False)
+
+
+def _fake_draft(*, status: str, source_csv_path: str):
+    return SimpleNamespace(
+        status=SimpleNamespace(value=status),
+        draft_yaml="datasetTitle: foo\ntables:\n  foo: {}\n",
+        draft_json={"tables": {"foo": {}}},
+        dataset_id="CS0007DS0999",
+        collection_id="CS0007",
+        raw_dataset_id="CSRDS0099",
+        source_csv_path=source_csv_path,
+    )
+
+
+def _service():
+    return WebAdminService()
+
+
+def test_import_dataset_from_draft_happy_path(monkeypatch, tmp_path):
+    csv_path = tmp_path / "foo.csv"
+    csv_path.write_bytes(b"a,b\n1,2\n")
+    draft = _fake_draft(status="approved", source_csv_path=json.dumps({"foo": str(csv_path)}))
+
+    service = _service()
+    monkeypatch.setattr(service.draft_review_service, "_get_draft_or_404", lambda draft_id: draft)
+    monkeypatch.setattr(
+        service.draft_review_service,
+        "generate_info_yaml",
+        lambda draft_id, access_level: {"info_yaml": f"ds_id: {draft.dataset_id}\naccess_level: {access_level}\n"},
+    )
+
+    captured = {}
+
+    def fake_import_dataset_package(
+        admin_user, info_file, metadata_file, csv_files, dataset_override=None,
+        raw_dataset_override=None, bucket_type=VersionType.STANDARDISED,
+    ):
+        captured["admin_user"] = admin_user
+        captured["info_text"] = info_file.file.read().decode("utf-8")
+        captured["metadata_text"] = metadata_file.file.read().decode("utf-8")
+        captured["csv_files"] = {f.filename: f.file.read().decode("utf-8") for f in csv_files}
+        captured["dataset_override"] = dataset_override
+        captured["bucket_type"] = bucket_type
+        return {"dataset_id": draft.dataset_id, "bucket_type": bucket_type.value, "uploaded_tables": ["foo"], "manifest_uploaded": True}
+
+    monkeypatch.setattr(service, "import_dataset_package", fake_import_dataset_package)
+
+    result = service.import_dataset_from_draft(ADMIN_USER, "draft-1", "VIEW", VersionType.STANDARDISED)
+
+    assert result["dataset_id"] == "CS0007DS0999"
+    assert "access_level: VIEW" in captured["info_text"]
+    assert captured["metadata_text"] == draft.draft_yaml
+    assert captured["csv_files"] == {"foo.csv": "a,b\n1,2\n"}
+    assert captured["dataset_override"] == {"existing_dataset_id": "CS0007DS0999"}
+    assert captured["bucket_type"] == VersionType.STANDARDISED
+
+
+def test_import_dataset_from_draft_rejects_non_approved(monkeypatch, tmp_path):
+    draft = _fake_draft(status="pending", source_csv_path=json.dumps({"foo": str(tmp_path / "foo.csv")}))
+
+    service = _service()
+    monkeypatch.setattr(service.draft_review_service, "_get_draft_or_404", lambda draft_id: draft)
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("import_dataset_package must not be called for a non-approved draft")
+
+    monkeypatch.setattr(service, "import_dataset_package", fail_if_called)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.import_dataset_from_draft(ADMIN_USER, "draft-1", "NONE", VersionType.STANDARDISED)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_import_dataset_from_draft_raises_clear_error_for_missing_csv(monkeypatch, tmp_path):
+    missing_path = tmp_path / "does_not_exist.csv"
+    draft = _fake_draft(status="approved", source_csv_path=json.dumps({"foo": str(missing_path)}))
+
+    service = _service()
+    monkeypatch.setattr(service.draft_review_service, "_get_draft_or_404", lambda draft_id: draft)
+    monkeypatch.setattr(
+        service.draft_review_service, "generate_info_yaml", lambda draft_id, access_level: {"info_yaml": "ds_id: x\n"}
+    )
+
+    def fail_if_called(*a, **kw):
+        raise AssertionError("import_dataset_package must not be called when a CSV can't be read")
+
+    monkeypatch.setattr(service, "import_dataset_package", fail_if_called)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.import_dataset_from_draft(ADMIN_USER, "draft-1", "NONE", VersionType.STANDARDISED)
+
+    assert exc_info.value.status_code == 400
+    assert "foo" in exc_info.value.detail

--- a/src/dataio/api/tests/test_info_yaml_builder.py
+++ b/src/dataio/api/tests/test_info_yaml_builder.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import yaml
+
+from dataio.api.services.info_yaml_builder import build_info_yaml
+
+
+def _draft_json(**overrides):
+    base = {
+        "datasetTitle": "consolidated-livestock-census",
+        "datasetOwner": "DAHD",
+        "datasetDescription": "State-level livestock population counts.",
+        "spatialResolution": "state",
+        "source": ["16th Livestock Census 1997", "17th Livestock Census 2003"],
+        "tables": {
+            "main": {
+                "data_dictionary": {
+                    "year": {
+                        "type": "date",
+                        "format": "%Y",
+                        "allowedValues": ["1997", "2003", "2007", "2012", "2019"],
+                    },
+                    "count": {"type": "int"},
+                }
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_build_info_yaml_derives_every_field_from_the_draft():
+    result = build_info_yaml(
+        _draft_json(),
+        dataset_id="CS0007DS0119",
+        collection_id="CS0007",
+        raw_dataset_id="CS0007RDS0005",
+        access_level="DOWNLOAD",
+    )
+    parsed = yaml.safe_load(result)
+
+    assert parsed == {
+        "ds_id": "CS0007DS0119",
+        "collection_id": "CS0007",
+        "title": "consolidated-livestock-census",
+        "data_owner_name": "DAHD",
+        "description": "State-level livestock population counts.",
+        "temporal_coverage_start_date": "1997",
+        "temporal_coverage_end_date": "2019",
+        "temporal_resolution": "YEAR",
+        "spatial_resolution": "STATE",
+        "access_level": "DOWNLOAD",
+        "raw_dataset": {
+            "rds_id": "CS0007RDS0005",
+            "source": "16th Livestock Census 1997; 17th Livestock Census 2003",
+        },
+    }
+
+
+def test_build_info_yaml_matches_hand_authored_key_order():
+    result = build_info_yaml(
+        _draft_json(),
+        dataset_id="CS0007DS0119",
+        collection_id="CS0007",
+        raw_dataset_id="CS0007RDS0005",
+        access_level="NONE",
+    )
+    keys = list(yaml.safe_load(result).keys())
+    assert keys == [
+        "ds_id", "collection_id", "title", "data_owner_name", "description",
+        "temporal_coverage_start_date", "temporal_coverage_end_date", "temporal_resolution",
+        "spatial_resolution", "access_level", "raw_dataset",
+    ]
+
+
+def test_build_info_yaml_scans_every_table_for_the_temporal_axis():
+    draft_json = _draft_json(
+        tables={
+            "no_dates": {
+                "data_dictionary": {"species": {"type": "enum", "enumRef": "speciesEnum"}},
+            },
+            "main": _draft_json()["tables"]["main"],
+        }
+    )
+    result = build_info_yaml(
+        draft_json, dataset_id="CS0007DS0119", collection_id="CS0007",
+        raw_dataset_id=None, access_level="NONE",
+    )
+    parsed = yaml.safe_load(result)
+    assert parsed["temporal_coverage_start_date"] == "1997"
+    assert parsed["temporal_coverage_end_date"] == "2019"
+
+
+def test_build_info_yaml_omits_missing_fields_instead_of_nulling_them():
+    result = build_info_yaml(
+        {"tables": {}},
+        dataset_id="CS0007DS0119",
+        collection_id="CS0007",
+        raw_dataset_id=None,
+        access_level="NONE",
+    )
+    parsed = yaml.safe_load(result)
+
+    assert parsed == {"ds_id": "CS0007DS0119", "collection_id": "CS0007", "access_level": "NONE"}
+    assert "raw_dataset" not in parsed
+    assert "title" not in parsed
+
+
+def test_build_info_yaml_uppercases_spatial_resolution():
+    result = build_info_yaml(
+        _draft_json(spatialResolution="district"),
+        dataset_id="CS0007DS0119", collection_id="CS0007",
+        raw_dataset_id=None, access_level="NONE",
+    )
+    assert yaml.safe_load(result)["spatial_resolution"] == "DISTRICT"
+
+
+def test_build_info_yaml_leaves_unrecognized_date_format_resolution_blank():
+    draft_json = _draft_json()
+    draft_json["tables"]["main"]["data_dictionary"]["year"]["format"] = "%Y-%m"
+    result = build_info_yaml(
+        draft_json, dataset_id="CS0007DS0119", collection_id="CS0007",
+        raw_dataset_id=None, access_level="NONE",
+    )
+    parsed = yaml.safe_load(result)
+    assert "temporal_resolution" not in parsed
+    # Start/end dates are still derived - only the resolution mapping is unknown.
+    assert parsed["temporal_coverage_start_date"] == "1997"

--- a/src/dataio/api/tests/test_manifest_draft_functions.py
+++ b/src/dataio/api/tests/test_manifest_draft_functions.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+import pytest
+
+from dataio.api.database.functions import _coerce_draft_id
+
+# The CRUD functions themselves (create_manifest_draft, get_manifest_draft,
+# etc.) open a real Session and are exercised against a live DB, matching
+# this repo's existing convention of not standing up a test DB for
+# dataio.api.database.functions - see test_admin_manifest_service.py, which
+# only ever monkeypatches these at the service-module boundary. This file
+# covers the one piece of pure logic that doesn't need a live session.
+
+
+def test_coerce_draft_id_accepts_uuid_instance():
+    value = uuid.uuid4()
+    assert _coerce_draft_id(value) == value
+
+
+def test_coerce_draft_id_accepts_string():
+    value = uuid.uuid4()
+    assert _coerce_draft_id(str(value)) == value
+
+
+def test_coerce_draft_id_rejects_garbage():
+    with pytest.raises(ValueError):
+        _coerce_draft_id("not-a-uuid")

--- a/src/dataio/api/tests/test_manifest_v2_conversion.py
+++ b/src/dataio/api/tests/test_manifest_v2_conversion.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import yaml
+
+from dataio.api.services.manifest_v2_conversion import (
+    convert_v2_field_to_manifest_field,
+    convert_v2_manifest_to_contract,
+)
+from dataio.validate.sdk import DataIOValidator
+
+V2_MANIFEST = {
+    "datasetTitle": "Consolidated Livestock Census",
+    "datasetSlug": "cs0007ds0112-consolidated-livestock-census",
+    "datasetID": "CS0007DS0112",
+    "metadataSpecVersion": "v2",
+    "source": ["16th Livestock Census 1997"],
+    "category": {"ID": "CS", "name": "Census and Surveys"},
+    "collection": {"ID": "CS0007", "name": "Livestock Census (by DAHD)"},
+    "datasetDescription": "State-level livestock counts.",
+    "datasetOwner": "DAHD",
+    "tags": {"concept": ["livestock"], "epiType": ["population"]},
+    "spatialCoverage": "India",
+    "spatialResolution": "state",
+    "temporalCoverage": "1997, 2003, 2007, 2012, 2019",
+    "temporalResolution": "quinquennial",
+    "updateFrequency": "Quinquennial",
+    "lastUpdated": "2026-07-21",
+    "comments": ["Covers cattle and buffalo only."],
+    "references": ["https://dahd.gov.in/report.pdf"],
+    "enumDefinitions": {
+        "livestockSpecies": {
+            "description": "Species",
+            "values": {"cattle": {"description": "Cattle"}, "buffalo": {"description": "Buffalo"}},
+        }
+    },
+    "tables": {
+        "consolidated-livestock-census": {
+            "description": "One row per state/year/species.",
+            "source": "16th-20th Livestock Census PDFs",
+            "joinKeys": ["state.ID", "year", "species"],
+            "data_dictionary": {
+                "year": {"type": "date", "format": "%Y", "description": "Census year", "nullable": False},
+                "species": {
+                    "type": "enum", "description": "Species", "nullable": False, "enumRef": "livestockSpecies",
+                },
+                "count": {"type": "int", "description": "Count", "nullable": False},
+            },
+        }
+    },
+}
+
+
+def test_convert_field_enum_resolves_enum_ref_against_manifest():
+    field = convert_v2_field_to_manifest_field(
+        "species",
+        {"type": "enum", "enumRef": "livestockSpecies"},
+        enum_scope=V2_MANIFEST,
+    )
+    assert field["type"] == "enum"
+    assert set(field["allowedValues"]) == {"cattle", "buffalo"}
+
+
+def test_convert_field_passes_through_plain_types():
+    field = convert_v2_field_to_manifest_field("count", {"type": "int", "nullable": False})
+    assert field["type"] == "int"
+    assert field["nullable"] is False
+
+
+def test_convert_field_carries_extra_keys_like_isjoinkey():
+    field = convert_v2_field_to_manifest_field(
+        "year", {"type": "date", "format": "%Y", "isJoinKey": True, "joinKeyType": "temporal"}
+    )
+    assert field["isJoinKey"] is True
+    assert field["joinKeyType"] == "temporal"
+
+
+def test_convert_manifest_renames_tables_to_dataset_tables():
+    contract = convert_v2_manifest_to_contract(V2_MANIFEST)
+
+    assert "tables" not in contract
+    assert "consolidated-livestock-census" in contract["datasetTables"]
+    table = contract["datasetTables"]["consolidated-livestock-census"]
+    assert "dataDictionary" in table
+    assert table["dataDictionary"]["species"]["allowedValues"] == ["cattle", "buffalo"]
+    assert contract["datasetKind"] == "tabular"
+    # required top-level fields carried through unchanged
+    assert contract["datasetID"] == "CS0007DS0112"
+    assert contract["category"] == {"ID": "CS", "name": "Census and Surveys"}
+
+
+def test_converted_manifest_passes_the_existing_validator():
+    """The whole point: this converted shape must actually pass
+    dataio.validate.sdk.DataIOValidator - the same validator every real
+    dataset in this system was checked against.
+    """
+    contract = convert_v2_manifest_to_contract(V2_MANIFEST)
+    manifest_yaml = yaml.safe_dump(contract, sort_keys=False)
+
+    result = DataIOValidator().validate_tabular(
+        manifest=manifest_yaml,
+        data_files={"consolidated-livestock-census": "year,species,count\n2019,cattle,10\n"},
+        deep_check=False,
+        full_scan=False,
+        max_rows=1,
+    )
+
+    errors = [f for f in result.findings if f.severity == "error"]
+    assert errors == [], errors
+
+
+def test_converted_real_production_manifest_passes_the_existing_validator():
+    """Convert the actual staging-format metadata.yaml on disk for
+    CS0007DS0112 and confirm it passes - matching the live manifest_yaml
+    already stored in Postgres for that same dataset (confirmed by
+    inspecting it directly: datasetTables, not tables).
+    """
+    with open(
+        "D:/dataio/data/CS0007DS0112-Consolidated-Livestock-Census-1997-2019/metadata.yaml",
+        encoding="utf-8",
+    ) as f:
+        real_manifest = yaml.safe_load(f)
+
+    contract = convert_v2_manifest_to_contract(real_manifest)
+    manifest_yaml = yaml.safe_dump(contract, sort_keys=False)
+
+    with open(
+        "D:/dataio/data/CS0007DS0112-Consolidated-Livestock-Census-1997-2019/"
+        "consolidated-livestock-census.csv",
+        encoding="utf-8",
+    ) as f:
+        csv_text = f.read()
+
+    result = DataIOValidator().validate_tabular(
+        manifest=manifest_yaml,
+        data_files={"consolidated-livestock-census": csv_text},
+        deep_check=False,
+        full_scan=False,
+        max_rows=5,
+    )
+
+    errors = [f for f in result.findings if f.severity == "error"]
+    assert errors == [], errors

--- a/src/dataio/api/tests/test_openrouter_draft_client.py
+++ b/src/dataio/api/tests/test_openrouter_draft_client.py
@@ -66,3 +66,44 @@ def test_complete_raises_readable_error_on_200_with_no_choices():
 
     with pytest.raises(RuntimeError, match="upstream provider overloaded"):
         client.complete(system_prompt="be terse", user_prompt="draft it")
+
+
+def test_complete_returns_empty_text_when_message_content_is_missing():
+    """Some providers omit "content" entirely on an otherwise well-formed
+    choices response - this must not raise a raw KeyError, since an empty
+    text string fails parse_llm_output's own format check the same way any
+    other malformed response does, routing into the existing retry path.
+    """
+    def missing_content_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"model": "x", "choices": [{"message": {"role": "assistant"}}]},
+        )
+
+    client = OpenRouterDraftClient()
+    client._client = httpx.Client(
+        base_url=client._client.base_url,
+        transport=httpx.MockTransport(missing_content_response),
+    )
+
+    completion = client.complete(system_prompt="be terse", user_prompt="draft it")
+
+    assert completion.text == ""
+
+
+def test_complete_returns_empty_text_when_message_content_is_null():
+    def null_content_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"model": "x", "choices": [{"message": {"role": "assistant", "content": None}}]},
+        )
+
+    client = OpenRouterDraftClient()
+    client._client = httpx.Client(
+        base_url=client._client.base_url,
+        transport=httpx.MockTransport(null_content_response),
+    )
+
+    completion = client.complete(system_prompt="be terse", user_prompt="draft it")
+
+    assert completion.text == ""

--- a/src/dataio/api/tests/test_openrouter_draft_client.py
+++ b/src/dataio/api/tests/test_openrouter_draft_client.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from dataio.api.services.openrouter_draft_client import OpenRouterDraftClient
+
+
+def _canned_response(request: httpx.Request) -> httpx.Response:
+    assert request.url.path.endswith("/chat/completions")
+    body = request.read()
+    import json
+
+    payload = json.loads(body)
+    assert payload["stream"] is False
+    assert payload["messages"][0]["role"] == "system"
+    assert payload["messages"][1]["role"] == "user"
+    return httpx.Response(
+        200,
+        json={
+            "model": "anthropic/claude-3.5-sonnet",
+            "choices": [{"message": {"role": "assistant", "content": "datasetTitle: Foo"}}],
+            "usage": {"prompt_tokens": 123, "completion_tokens": 45},
+        },
+    )
+
+
+def test_complete_parses_non_streaming_response():
+    client = OpenRouterDraftClient()
+    client._client = httpx.Client(
+        base_url=client._client.base_url,
+        transport=httpx.MockTransport(_canned_response),
+    )
+
+    completion = client.complete(system_prompt="be terse", user_prompt="draft it")
+
+    assert completion.text == "datasetTitle: Foo"
+    assert completion.model == "anthropic/claude-3.5-sonnet"
+    assert completion.prompt_tokens == 123
+    assert completion.completion_tokens == 45
+
+
+def test_complete_raises_on_non_200():
+    def error_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = OpenRouterDraftClient()
+    client._client = httpx.Client(
+        base_url=client._client.base_url,
+        transport=httpx.MockTransport(error_response),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        client.complete(system_prompt="be terse", user_prompt="draft it")

--- a/src/dataio/api/tests/test_openrouter_draft_client.py
+++ b/src/dataio/api/tests/test_openrouter_draft_client.py
@@ -52,3 +52,17 @@ def test_complete_raises_on_non_200():
 
     with pytest.raises(httpx.HTTPStatusError):
         client.complete(system_prompt="be terse", user_prompt="draft it")
+
+
+def test_complete_raises_readable_error_on_200_with_no_choices():
+    def no_choices_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"error": {"message": "upstream provider overloaded"}})
+
+    client = OpenRouterDraftClient()
+    client._client = httpx.Client(
+        base_url=client._client.base_url,
+        transport=httpx.MockTransport(no_choices_response),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream provider overloaded"):
+        client.complete(system_prompt="be terse", user_prompt="draft it")

--- a/src/dataio/api/tests/test_rds_id_helpers.py
+++ b/src/dataio/api/tests/test_rds_id_helpers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "catalogue")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+import pytest
+
+from dataio.api.database.rds_id_helpers import resolve_category_id, resolve_rds_id
+
+
+def test_resolve_category_id_prefers_explicit_category():
+    meta = {"category": {"ID": "CS", "name": "Census and Surveys"}, "collection": {"ID": "CS0007"}}
+    assert resolve_category_id(meta) == "CS"
+
+
+def test_resolve_category_id_falls_back_to_collection_id():
+    meta = {"collection": {"ID": "CS0007", "name": "Livestock Census"}}
+    assert resolve_category_id(meta) == "CS"
+
+
+def test_resolve_category_id_empty_when_nothing_present():
+    assert resolve_category_id({}) == ""
+
+
+def test_resolve_rds_id_calls_db_counter(monkeypatch):
+    calls = {}
+
+    def fake_suggest(category_id):
+        calls["category_id"] = category_id
+        return "CSRDS0016"
+
+    monkeypatch.setattr(
+        "dataio.api.database.rds_id_helpers.suggest_next_raw_dataset_id_for_category",
+        fake_suggest,
+    )
+
+    meta = {"category": {"ID": "CS"}, "collection": {"ID": "CS0007"}}
+    assert resolve_rds_id(meta) == "CSRDS0016"
+    assert calls["category_id"] == "CS"
+
+
+def test_resolve_rds_id_raises_without_any_category_info():
+    with pytest.raises(ValueError):
+        resolve_rds_id({})

--- a/src/dataio/api/tests/test_region_gap_detector.py
+++ b/src/dataio/api/tests/test_region_gap_detector.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
+
+from dataio.api.services import region_gap_detector
 from dataio.api.services.region_gap_detector import detect_region_gaps, detect_region_gaps_for_table
 
 
@@ -78,3 +81,42 @@ def test_detect_region_gaps_for_table_finds_the_region_and_date_columns_automati
     comments = detect_region_gaps_for_table(csv_path, data_dictionary)
 
     assert any("Telangana" in c for c in comments)
+
+
+def test_detect_region_gaps_ignores_blank_region_values_without_treating_them_as_a_region(tmp_path: Path):
+    # A blank/missing region cell must not survive as the literal string
+    # "nan" (a pandas astype(str) artifact) and get treated as if it were
+    # a real (bogus) region name anywhere in the output.
+    csv_path = _write_csv(tmp_path, [("", 2015), ("Telangana", 2019)])
+
+    comments = detect_region_gaps(csv_path, "state.name", "year")
+
+    assert any("Telangana" in c for c in comments)
+    assert not any("nan" in c.lower() for c in comments)
+
+
+def test_detect_region_gaps_for_table_reads_the_csv_only_once(tmp_path: Path, monkeypatch):
+    # 2 region columns x 1 date column = 2 pairs to check, but the CSV
+    # itself must only be read from disk once, not once per pair.
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text(
+        "state.name,district.name,year\nAndhra Pradesh,Guntur,1997\nTelangana,Hyderabad,2019\n",
+        encoding="utf-8",
+    )
+    data_dictionary = {
+        "state.name": {"type": "regionName"},
+        "district.name": {"type": "regionName"},
+        "year": {"type": "date", "format": "%Y"},
+    }
+    real_read_csv = pd.read_csv
+    calls: list[None] = []
+
+    def counting_read_csv(*args, **kwargs):
+        calls.append(None)
+        return real_read_csv(*args, **kwargs)
+
+    monkeypatch.setattr(region_gap_detector.pd, "read_csv", counting_read_csv)
+
+    detect_region_gaps_for_table(str(csv_path), data_dictionary)
+
+    assert len(calls) == 1

--- a/src/dataio/api/tests/test_region_gap_detector.py
+++ b/src/dataio/api/tests/test_region_gap_detector.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dataio.api.services.region_gap_detector import detect_region_gaps, detect_region_gaps_for_table
+
+
+def _write_csv(tmp_path: Path, rows: list[tuple[str, int]]) -> str:
+    csv_path = tmp_path / "data.csv"
+    lines = ["state.name,year"] + [f"{state},{year}" for state, year in rows]
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(csv_path)
+
+
+def test_detect_region_gaps_notes_known_event_when_data_matches_expected_pattern(tmp_path: Path):
+    # Telangana only appears from 2019 onward - consistent with its real
+    # 2014-06-02 effective date, so no anomaly warning should fire.
+    csv_path = _write_csv(tmp_path, [
+        ("Andhra Pradesh", 1997), ("Andhra Pradesh", 2012), ("Telangana", 2019),
+    ])
+
+    comments = detect_region_gaps(csv_path, "state.name", "year")
+
+    telangana_comments = [c for c in comments if "Telangana" in c]
+    assert len(telangana_comments) == 1
+    assert telangana_comments[0].startswith("[region history]")
+    assert "as early as" not in telangana_comments[0]  # no anomaly - matches documented history
+
+
+def test_detect_region_gaps_flags_anomaly_when_region_appears_before_effective_date(tmp_path: Path):
+    # Telangana appearing in 2010 data contradicts its real 2014 formation -
+    # worth surfacing to a curator rather than silently trusting the data.
+    csv_path = _write_csv(tmp_path, [("Telangana", 2010)])
+
+    comments = detect_region_gaps(csv_path, "state.name", "year")
+
+    telangana_comments = [c for c in comments if "Telangana" in c]
+    assert len(telangana_comments) == 1
+    assert "as early as 2010" in telangana_comments[0]
+    assert "2014-06-02" in telangana_comments[0]
+
+
+def test_detect_region_gaps_matches_regardless_of_case(tmp_path: Path):
+    # Regression: the real ARTPARK livestock census CSVs store state names
+    # in ALL CAPS ("TELANGANA"), which must still match region_history.yaml's
+    # human-readable casing ("Telangana").
+    csv_path = _write_csv(tmp_path, [("ANDHRA PRADESH", 1997), ("TELANGANA", 2019)])
+
+    comments = detect_region_gaps(csv_path, "state.name", "year")
+
+    assert any("Telangana" in c and "as early as" not in c for c in comments)
+
+
+def test_detect_region_gaps_skips_events_whose_region_is_absent_from_data(tmp_path: Path):
+    csv_path = _write_csv(tmp_path, [("Karnataka", 2019), ("Kerala", 2019)])
+
+    comments = detect_region_gaps(csv_path, "state.name", "year")
+
+    assert comments == []
+
+
+def test_detect_region_gaps_for_table_requires_both_region_name_and_date_columns():
+    only_region = {"state.name": {"type": "regionName"}, "count": {"type": "int"}}
+    only_date = {"year": {"type": "date", "format": "%Y"}, "count": {"type": "int"}}
+
+    assert detect_region_gaps_for_table("unused.csv", only_region) == []
+    assert detect_region_gaps_for_table("unused.csv", only_date) == []
+
+
+def test_detect_region_gaps_for_table_finds_the_region_and_date_columns_automatically(tmp_path: Path):
+    csv_path = _write_csv(tmp_path, [("Andhra Pradesh", 1997), ("Telangana", 2019)])
+    data_dictionary = {
+        "state.name": {"type": "regionName"},
+        "year": {"type": "date", "format": "%Y"},
+        "count": {"type": "int"},
+    }
+
+    comments = detect_region_gaps_for_table(csv_path, data_dictionary)
+
+    assert any("Telangana" in c for c in comments)

--- a/src/dataio/api/tests/test_temporal_resolution_mapping.py
+++ b/src/dataio/api/tests/test_temporal_resolution_mapping.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from dataio.api.database.enums import TemporalResolution
+from dataio.api.database.temporal_resolution_mapping import (
+    is_lossy_temporal_resolution,
+    resolve_temporal_resolution,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("YEAR", TemporalResolution.YEAR.value),
+        ("year", TemporalResolution.YEAR.value),
+        ("quinquennial", TemporalResolution.YEAR.value),
+        ("decadal", TemporalResolution.YEAR.value),
+        ("monthly", TemporalResolution.MONTH.value),
+        ("Weekly", TemporalResolution.WEEK.value),
+        ("daily", TemporalResolution.DATE.value),
+        ("hourly", TemporalResolution.HOUR.value),
+        ("static", TemporalResolution.NONE.value),
+    ],
+)
+def test_resolve_temporal_resolution_maps_known_values(raw, expected):
+    assert resolve_temporal_resolution(raw) == expected
+
+
+def test_resolve_temporal_resolution_raises_on_unknown_value():
+    with pytest.raises(ValueError) as exc_info:
+        resolve_temporal_resolution("fortnightly")
+    # error message should list the real valid enum values so the caller
+    # can fix the source metadata.yaml or extend the mapping table
+    assert "YEAR" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("quinquennial", True),
+        ("decadal", True),
+        ("year", False),
+        ("monthly", False),
+    ],
+)
+def test_is_lossy_temporal_resolution(raw, expected):
+    assert is_lossy_temporal_resolution(raw) == expected

--- a/src/dataio/cli/cli.py
+++ b/src/dataio/cli/cli.py
@@ -1,5 +1,6 @@
 import typer
 
+from dataio.cli.draft import app as draft_app
 from dataio.cli.user import app as user_app
 from dataio.cli.validate import app as validate_app
 
@@ -16,6 +17,7 @@ app.add_typer(
     "Using this sub-app is optional, and the recommended way to interact with the root dataio command.",
 )
 app.add_typer(validate_app, name="validate", help="Validate manifests and data files locally.")
+app.add_typer(draft_app, name="draft", help="Draft dataset metadata.yaml using an LLM, for curator review.")
 
 if __name__ == "__main__":
     app()

--- a/src/dataio/cli/draft.py
+++ b/src/dataio/cli/draft.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import List
+
+import typer
+
+app = typer.Typer(
+    help="Draft dataset metadata.yaml from a raw CSV using an LLM, for curator review. "
+    "Requires the 'api' extras group (pip install \"dataio-artpark[api]\") plus DB and "
+    "OPENROUTER_API_KEY env vars - this is an internal ops tool, not part of the public SDK."
+)
+
+
+@app.command("generate")
+def generate(
+    csv: List[str] = typer.Option(
+        ..., "--csv", help="Path to a raw CSV file. Repeat --csv once per table for a multi-table dataset."
+    ),
+    category_id: str = typer.Option(..., "--category-id", help='e.g. "CS".'),
+    collection_id: str = typer.Option(..., "--collection-id", help='e.g. "CS0007".'),
+    data_owner_name: str = typer.Option(..., "--data-owner-name", help='e.g. "DAHD".'),
+    created_by: str = typer.Option(..., "--created-by", help="Email of the requesting user."),
+    dataset_id: str = typer.Option(None, "--dataset-id", help="Existing ds_id, if updating an existing dataset."),
+    digitization_log: str = typer.Option(None, "--digitization-log", help="Path to digitization_log.yaml."),
+):
+    # Lazy import: this pulls in dataio.api.database (and pandas), neither of
+    # which ship in the public dataio-artpark wheel/sdist. Importing it at
+    # module top-level would break `dataio` for anyone who installed the
+    # public package without the `api` extras, since cli.py imports every
+    # registered sub-app's module eagerly.
+    from dataio.api.services.draft_service import generate_draft
+
+    draft = generate_draft(
+        csv_paths=csv,
+        category_id=category_id,
+        collection_id=collection_id,
+        data_owner_name=data_owner_name,
+        created_by=created_by,
+        dataset_id=dataset_id,
+        digitization_log_path=digitization_log,
+    )
+    typer.echo(f"Draft created: {draft.draft_id} (status={draft.status}, validation={draft.validation_status})")
+    if draft.flagged_fields:
+        typer.echo("Flagged fields:")
+        for flag in draft.flagged_fields:
+            typer.echo(f"  - {flag.get('field')}: {flag.get('reason')}")
+    raise typer.Exit(0)

--- a/src/dataio/db/migrations/018_dataset_manifest_drafts.sql
+++ b/src/dataio/db/migrations/018_dataset_manifest_drafts.sql
@@ -1,0 +1,40 @@
+-- Migration 018: Dataset Manifest Drafts
+-- Staging area for LLM-drafted metadata.yaml, reviewed by a curator before
+-- ever reaching the real store (datasets.manifest_yaml / S3 via
+-- filestore_service). Deliberately separate from both of those: VersionType
+-- (PREPROCESSED/STANDARDISED) represents pipeline stage, not review state,
+-- and the datasets table only ever holds the live approved manifest.
+
+BEGIN;
+
+CREATE TYPE dataset_manifest_draft_status AS ENUM ('pending', 'approved', 'rejected', 'flagged');
+
+CREATE TABLE IF NOT EXISTS dataset_manifest_drafts (
+    draft_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dataset_id TEXT NULL,              -- nullable: brand-new datasets don't have a ds_id yet
+    collection_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,         -- used for suggest_next_raw_dataset_id_for_category + audit
+    source_csv_path TEXT NOT NULL,     -- what the drafter read, for reproducibility
+    digitization_log_path TEXT NULL,
+    status dataset_manifest_draft_status NOT NULL DEFAULT 'pending',
+    draft_yaml TEXT NOT NULL,
+    draft_json JSONB NOT NULL,
+    flagged_fields JSONB NOT NULL DEFAULT '[]'::jsonb,
+    reviewer_notes JSONB NOT NULL DEFAULT '[]'::jsonb,
+    validation_result JSONB NULL,
+    llm_model_id TEXT NOT NULL,
+    llm_prompt_tokens INTEGER NULL,
+    llm_completion_tokens INTEGER NULL,
+    created_by TEXT NOT NULL REFERENCES users(email),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reviewed_by TEXT NULL REFERENCES users(email),
+    reviewed_at TIMESTAMP NULL,
+    superseded_by_draft_id UUID NULL REFERENCES dataset_manifest_drafts(draft_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dataset_manifest_drafts_status ON dataset_manifest_drafts(status);
+CREATE INDEX IF NOT EXISTS idx_dataset_manifest_drafts_dataset_id ON dataset_manifest_drafts(dataset_id);
+
+SELECT add_migration(18, '018_dataset_manifest_drafts');
+
+COMMIT;

--- a/src/dataio/db/migrations/018_dataset_manifest_drafts_rollback.sql
+++ b/src/dataio/db/migrations/018_dataset_manifest_drafts_rollback.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS dataset_manifest_drafts;
+DROP TYPE IF EXISTS dataset_manifest_draft_status;

--- a/src/dataio/db/migrations/019_dataset_manifest_drafts_raw_dataset_id.sql
+++ b/src/dataio/db/migrations/019_dataset_manifest_drafts_raw_dataset_id.sql
@@ -1,0 +1,16 @@
+-- Migration 019: track the resolved raw_dataset_id on the draft row itself,
+-- not inside draft_json/draft_yaml. metadata.yaml never contains a
+-- raw_dataset/rds_id field in real production files - that belongs only in
+-- info.yml, generated later. Storing it as a column here (rather than
+-- polluting the manifest) keeps the drafted YAML schema-pure while still
+-- letting a curator see it during review and carry it into info.yml when
+-- they manually import the approved draft (approve_draft itself does not
+-- create a RawDataset row - see DatasetManifestDraft's docstring).
+
+BEGIN;
+
+ALTER TABLE dataset_manifest_drafts ADD COLUMN IF NOT EXISTS raw_dataset_id TEXT NULL;
+
+SELECT add_migration(19, '019_dataset_manifest_drafts_raw_dataset_id');
+
+COMMIT;

--- a/src/dataio/db/migrations/019_dataset_manifest_drafts_raw_dataset_id_rollback.sql
+++ b/src/dataio/db/migrations/019_dataset_manifest_drafts_raw_dataset_id_rollback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dataset_manifest_drafts DROP COLUMN IF EXISTS raw_dataset_id;

--- a/src/dataio/db/migrations/020_reserved_raw_dataset_ids.sql
+++ b/src/dataio/db/migrations/020_reserved_raw_dataset_ids.sql
@@ -1,0 +1,24 @@
+-- Migration 020: Reserved Raw Dataset IDs
+-- Mirrors reserved_dataset_ids (017) but for rds_id, which is scoped by
+-- category rather than collection. Needed so two concurrent LLM-drafted
+-- manifests in the same category can't be handed the same suggested
+-- rds_id: generate_draft reserves the id it resolves immediately, the same
+-- way it already reserves a fresh ds_id via reserved_dataset_ids.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS reserved_raw_dataset_ids (
+    id SERIAL PRIMARY KEY,
+    rds_id TEXT NOT NULL UNIQUE,
+    category_id TEXT NULL,
+    note TEXT NULL,
+    reserved_by TEXT NOT NULL REFERENCES users(email),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_reserved_raw_dataset_ids_category_id
+    ON reserved_raw_dataset_ids(category_id);
+
+SELECT add_migration(20, '020_reserved_raw_dataset_ids');
+
+COMMIT;

--- a/src/dataio/db/migrations/020_reserved_raw_dataset_ids_rollback.sql
+++ b/src/dataio/db/migrations/020_reserved_raw_dataset_ids_rollback.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS reserved_raw_dataset_ids;

--- a/src/dataio/db/migrations/021_manifest_draft_llm_model_id_nullable.sql
+++ b/src/dataio/db/migrations/021_manifest_draft_llm_model_id_nullable.sql
@@ -1,0 +1,15 @@
+-- Migration 021: Allow NULL llm_model_id on dataset_manifest_drafts
+-- llm_model_id was originally NOT NULL (018) since every draft came from
+-- the LLM drafter. The deterministic (no-LLM) draft path added this
+-- session sets llm_model_id=None deliberately - that's how the app tells
+-- a deterministic draft apart from an LLM one (see
+-- draft_review_service.regenerate_draft's dispatch, DraftDetail's "Model:
+-- Deterministic (rule-based)" display) - so the column must allow NULL.
+
+BEGIN;
+
+ALTER TABLE dataset_manifest_drafts ALTER COLUMN llm_model_id DROP NOT NULL;
+
+SELECT add_migration(21, '021_manifest_draft_llm_model_id_nullable');
+
+COMMIT;

--- a/src/dataio/db/migrations/021_manifest_draft_llm_model_id_nullable_rollback.sql
+++ b/src/dataio/db/migrations/021_manifest_draft_llm_model_id_nullable_rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback 021: restores NOT NULL on llm_model_id. Only safe if no
+-- deterministic (llm_model_id IS NULL) drafts exist yet - back-fill or
+-- delete them first, otherwise this ALTER will fail with a constraint
+-- violation, the same way the original bug surfaced.
+ALTER TABLE dataset_manifest_drafts ALTER COLUMN llm_model_id SET NOT NULL;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataio-web",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataio-web",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "dependencies": {
         "@astrojs/check": "^0.9.0",
         "@astrojs/preact": "^4.0.4",
@@ -14,7 +14,8 @@
         "astro": "^5.16.11",
         "jszip": "^3.10.1",
         "marked": "^15.0.0",
-        "preact": "^10.24.0"
+        "preact": "^10.24.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@astrojs/tailwind": "^6.0.0",
@@ -8355,9 +8356,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
     "astro": "^5.16.11",
     "jszip": "^3.10.1",
     "marked": "^15.0.0",
-    "preact": "^10.24.0"
+    "preact": "^10.24.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.0",

--- a/web/src/components/admin/AdminDatasetsHub.tsx
+++ b/web/src/components/admin/AdminDatasetsHub.tsx
@@ -2,26 +2,36 @@ import { useEffect, useState } from 'preact/hooks';
 
 import { api } from '../../lib/api';
 
+// null = could not be determined (that one call failed) - distinct from a
+// real 0, so the card can say "unavailable" instead of lying with a zero.
 type HubStats = {
-  datasets: number;
-  reservedIds: number;
-  outdatedDocs: number;
-  rawDatasets: number;
+  datasets: number | null;
+  reservedIds: number | null;
+  outdatedDocs: number | null;
+  rawDatasets: number | null;
+  pendingDrafts: number | null;
 };
 
 const defaultStats: HubStats = {
-  datasets: 0,
-  reservedIds: 0,
-  outdatedDocs: 0,
-  rawDatasets: 0,
+  datasets: null,
+  reservedIds: null,
+  outdatedDocs: null,
+  rawDatasets: null,
+  pendingDrafts: null,
 };
 
 const actionCards = [
   {
+    title: 'Metadata-Drafts',
+    description: 'Review LLM-drafted metadata.yaml pending curator approval before anything is uploaded.',
+    href: '/admin/datasets/drafts',
+    tone: 'bg-slate-900 text-white',
+  },
+  {
     title: 'Import Dataset Package',
     description: 'Validate info.yml and metadata.yml, review fixes, then upload matching CSV tables.',
     href: '/admin/datasets/new',
-    tone: 'bg-slate-900 text-white',
+    tone: 'bg-white text-slate-900 border border-slate-200',
   },
   {
     title: 'Browse Existing Datasets',
@@ -33,6 +43,12 @@ const actionCards = [
     title: 'Reserve Dataset ID',
     description: 'Claim identifiers for incoming datasets and keep the intake queue visible.',
     href: '/admin/datasets/reservations',
+    tone: 'bg-white text-slate-900 border border-slate-200',
+  },
+  {
+    title: 'Next Available ID',
+    description: 'Look up the next free dataset ID and raw dataset ID for a collection before authoring metadata.',
+    href: '/admin/datasets/next-id',
     tone: 'bg-white text-slate-900 border border-slate-200',
   },
   {
@@ -54,29 +70,43 @@ export default function AdminDatasetsHub() {
     async function load() {
       setLoading(true);
       setError('');
-      try {
-        const [datasetsResponse, reservationsResponse, syncResponse, rawDatasetsResponse] = await Promise.all([
+
+      // allSettled, not all: a single failed call must not zero out every
+      // other stat on this page (see the check_all=true note below for what
+      // used to fail here specifically).
+      const [datasetsResult, reservationsResult, syncResult, rawDatasetsResult, draftsResult] =
+        await Promise.allSettled([
           api.adminListDatasets({ limit: 1, offset: 0 }),
-          api.adminListReservedDatasetIds({ limit: 100, offset: 0 }),
-          api.adminCheckDocumentationSync(),
+          api.adminListReservedDatasetIds({ limit: 1, offset: 0 }),
+          // check_all=true: this summary card needs every dataset's status,
+          // not one interactive dataset_id lookup - the bare call used to
+          // 400 every time since the endpoint requires one or the other.
+          api.adminCheckDocumentationSync(undefined, true),
           api.adminListRawDatasets({ limit: 1, offset: 0 }),
+          api.adminListManifestDrafts({ status: 'pending', limit: 1, offset: 0 }),
         ]);
 
-        if (cancelled) return;
-        setStats({
-          datasets: datasetsResponse.total,
-          reservedIds: reservationsResponse.reservations.length,
-          outdatedDocs: syncResponse.outdated,
-          rawDatasets: rawDatasetsResponse.total,
-        });
-      } catch (err) {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Failed to load dataset admin summary');
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+      if (cancelled) return;
+
+      setStats({
+        datasets: datasetsResult.status === 'fulfilled' ? datasetsResult.value.total : null,
+        // .total, not .reservations.length - the array is capped by `limit`,
+        // so length silently stops growing past that cap while the real
+        // count keeps climbing.
+        reservedIds: reservationsResult.status === 'fulfilled' ? reservationsResult.value.total : null,
+        outdatedDocs: syncResult.status === 'fulfilled' ? syncResult.value.outdated : null,
+        rawDatasets: rawDatasetsResult.status === 'fulfilled' ? rawDatasetsResult.value.total : null,
+        pendingDrafts: draftsResult.status === 'fulfilled' ? draftsResult.value.total : null,
+      });
+
+      const failed = [datasetsResult, reservationsResult, syncResult, rawDatasetsResult, draftsResult].some(
+        (r) => r.status === 'rejected'
+      );
+      if (failed) {
+        setError('Some stats could not be loaded - see individual cards below.');
       }
+
+      setLoading(false);
     }
 
     load();
@@ -91,28 +121,38 @@ export default function AdminDatasetsHub() {
         <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
       ) : null}
 
-      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
         <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <div class="text-sm font-medium text-slate-500">Datasets</div>
-          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.datasets}</div>
+          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.datasets ?? '—'}</div>
           <p class="mt-2 text-sm text-slate-600">Published datasets currently visible in the admin catalog.</p>
         </div>
 
         <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <div class="text-sm font-medium text-slate-500">Reserved IDs</div>
-          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.reservedIds}</div>
+          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.reservedIds ?? '—'}</div>
           <p class="mt-2 text-sm text-slate-600">Held for incoming datasets before metadata or files are uploaded.</p>
         </div>
 
         <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div class="text-sm font-medium text-slate-500">Metadata-Drafts</div>
+          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.pendingDrafts ?? '—'}</div>
+          <p class="mt-2 text-sm text-slate-600">LLM-drafted metadata.yaml awaiting curator review.</p>
+        </div>
+
+        <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <div class="text-sm font-medium text-slate-500">Outdated Docs</div>
-          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.outdatedDocs}</div>
-          <p class="mt-2 text-sm text-slate-600">Datasets whose cached README, manifest, or dictionary may need a refresh.</p>
+          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.outdatedDocs ?? '—'}</div>
+          <p class="mt-2 text-sm text-slate-600">
+            {stats.outdatedDocs === null && !loading
+              ? 'Could not be checked just now - try refreshing.'
+              : 'Datasets whose cached README, manifest, or dictionary may need a refresh.'}
+          </p>
         </div>
 
         <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <div class="text-sm font-medium text-slate-500">Raw Datasets</div>
-          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.rawDatasets}</div>
+          <div class="mt-2 text-3xl font-semibold text-slate-900">{loading ? '…' : stats.rawDatasets ?? '—'}</div>
           <p class="mt-2 text-sm text-slate-600">Available raw sources that can be linked into dataset metadata.</p>
         </div>
       </div>

--- a/web/src/components/admin/AdminDatasetsSubnav.astro
+++ b/web/src/components/admin/AdminDatasetsSubnav.astro
@@ -3,6 +3,7 @@ const currentPath = Astro.url.pathname;
 
 const items = [
   { href: '/admin/datasets', label: 'Overview' },
+  { href: '/admin/datasets/drafts', label: 'Metadata Drafts' },
   { href: '/admin/datasets/new', label: 'Create / Import' },
   { href: '/admin/datasets/catalog', label: 'Catalog' },
   { href: '/admin/datasets/reservations', label: 'Reserved IDs' },

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -3,6 +3,7 @@ import { stringify as stringifyYaml } from 'yaml';
 
 import { ApiRequestError, api } from '../../lib/api';
 import type {
+  AccessLevel,
   Collection,
   CuratorMetadataInput,
   DataOwner,
@@ -74,7 +75,15 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
   const [dataOwnerName, setDataOwnerName] = useState('');
   const [datasetId, setDatasetId] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!submitting) return;
+    setElapsedSeconds(0);
+    const interval = setInterval(() => setElapsedSeconds((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, [submitting]);
 
   useEffect(() => {
     if (!open || collections.length > 0) return;
@@ -254,8 +263,25 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
         disabled={submitting || csvFiles.length === 0 || !categoryId || !collectionId || !dataOwnerName}
         class="w-full rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
       >
-        {submitting ? 'Generating… (this calls the LLM, may take a moment)' : 'Generate draft'}
+        {submitting ? 'Generating…' : 'Generate draft'}
       </button>
+      {submitting ? (
+        <div class="space-y-1.5">
+          <div class="h-1.5 w-full overflow-hidden rounded-full bg-emerald-100">
+            <div class="h-full w-1/3 animate-[llm-progress_1.4s_ease-in-out_infinite] rounded-full bg-emerald-500" />
+          </div>
+          <p class="text-center text-[11px] text-slate-500">
+            Calling the LLM — this reads the full CSV(s), so it can take a while. {elapsedSeconds}s elapsed…
+          </p>
+        </div>
+      ) : null}
+      <style>{`
+        @keyframes llm-progress {
+          0% { margin-left: 0%; }
+          50% { margin-left: 67%; }
+          100% { margin-left: 0%; }
+        }
+      `}</style>
     </form>
   );
 }
@@ -936,6 +962,9 @@ function DraftDetail({ draftId }: { draftId: string }) {
   const [editing, setEditing] = useState(false);
   const [editedYaml, setEditedYaml] = useState('');
   const [numericFields, setNumericFields] = useState<NumericFieldEntry[]>([]);
+  const [infoYamlAccessLevel, setInfoYamlAccessLevel] = useState<AccessLevel>('NONE');
+  const [infoYamlBusy, setInfoYamlBusy] = useState(false);
+  const [infoYamlError, setInfoYamlError] = useState('');
 
   const load = async () => {
     setLoading(true);
@@ -993,6 +1022,26 @@ function DraftDetail({ draftId }: { draftId: string }) {
       }
       await api.adminUpdateManifestDraftContent(draftId, stringifyYaml(updated));
     });
+  };
+
+  const downloadInfoYaml = async () => {
+    if (!draft) return;
+    setInfoYamlBusy(true);
+    setInfoYamlError('');
+    try {
+      const result = await api.adminGenerateManifestDraftInfoYaml(draftId, infoYamlAccessLevel);
+      const blob = new Blob([result.info_yaml], { type: 'application/x-yaml' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'info.yml';
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setInfoYamlError(errorMessage(err, 'Failed to generate info.yml'));
+    } finally {
+      setInfoYamlBusy(false);
+    }
   };
 
   if (loading) {
@@ -1235,6 +1284,42 @@ function DraftDetail({ draftId }: { draftId: string }) {
           </div>
         </div>
       ) : null}
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <div>
+            <h3 class="text-sm font-semibold text-slate-900">Generate info.yml</h3>
+            <p class="mt-1 text-xs text-slate-500">
+              {draft.status === 'approved'
+                ? "The second file the real dataset import needs, alongside metadata.yaml - derived from this draft's reviewed fields. Access level isn't captured anywhere upstream, so pick it here before downloading."
+                : 'Available once this draft is approved, so info.yml reflects the final reviewed manifest rather than a still-changeable draft. Approve it above first.'}
+            </p>
+          </div>
+          <div class="flex shrink-0 items-center gap-2">
+            <select
+              class="rounded-lg border border-slate-300 px-2 py-1 text-xs disabled:opacity-50"
+              value={infoYamlAccessLevel}
+              disabled={draft.status !== 'approved'}
+              onChange={(e) => setInfoYamlAccessLevel((e.target as HTMLSelectElement).value as AccessLevel)}
+            >
+              <option value="NONE">NONE</option>
+              <option value="VIEW">VIEW</option>
+              <option value="DOWNLOAD">DOWNLOAD</option>
+            </select>
+            <button
+              type="button"
+              disabled={infoYamlBusy || draft.status !== 'approved'}
+              onClick={downloadInfoYaml}
+              class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+            >
+              {infoYamlBusy ? 'Generating…' : 'Download info.yml'}
+            </button>
+          </div>
+        </div>
+        {infoYamlError ? (
+          <div class="rounded-lg bg-red-50 p-2 text-xs text-red-700 ring-1 ring-red-200">{infoYamlError}</div>
+        ) : null}
+      </div>
 
       <div class="rounded-2xl border border-slate-200 bg-white p-4">
         <div class="mb-2 flex items-center justify-between">

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -31,6 +31,25 @@ function statusClasses(status: ManifestDraftStatus) {
   return 'bg-slate-100 text-slate-700 ring-slate-200';
 }
 
+// Backend timestamps (e.g. draft.created_at) are naive UTC - Python's
+// datetime.utcnow().isoformat() has no trailing "Z"/offset. A bare
+// date-time string with no timezone designator is parsed by JS `Date` as
+// *local* time, not UTC, so without this the displayed time is the raw
+// UTC clock reading mislabeled as local (off by the viewer's UTC offset -
+// e.g. ~5.5 hours early in IST). Appending "Z" (only if not already
+// timezone-qualified) makes the browser convert it correctly.
+function formatUtcTimestamp(isoString: string): string {
+  const hasTimezone = /[zZ]|[+-]\d\d:?\d\d$/.test(isoString);
+  const date = new Date(hasTimezone ? isoString : `${isoString}Z`);
+  return date.toLocaleString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
 function severityClasses(severity: string) {
   if (severity === 'error') return 'bg-red-50 text-red-700 ring-red-200';
   if (severity === 'warning') return 'bg-amber-50 text-amber-700 ring-amber-200';
@@ -517,55 +536,6 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           ) : null}
         </label>
 
-        {tableNames.length > 0 ? (
-          <div class="space-y-4 md:col-span-2">
-            {classifyError ? (
-              <div class="rounded-lg bg-red-50 p-2 text-xs text-red-700 ring-1 ring-red-200">{classifyError}</div>
-            ) : null}
-            {tableNames.map((name) => (
-              <div key={name} class="space-y-2 rounded-xl border border-slate-100 p-3">
-                <label class="block text-xs font-medium text-slate-600">
-                  <span>Table description — {name}</span>
-                  <textarea
-                    class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
-                    rows={2}
-                    value={tableDescriptions[name] || ''}
-                    placeholder="e.g. State-level livestock population counts disaggregated by species, breed, sex, age group, utility, and locality."
-                    onInput={(e) =>
-                      setTableDescriptions((prev) => ({ ...prev, [name]: (e.target as HTMLTextAreaElement).value }))
-                    }
-                  />
-                </label>
-
-                {(columnsByTable[name] || []).length > 0 ? (
-                  <div class="space-y-1.5 pl-3">
-                    <p class="text-[11px] font-medium uppercase tracking-wide text-slate-400">
-                      Column descriptions — {name}
-                    </p>
-                    {(columnsByTable[name] || []).map((col) => (
-                      <label key={col} class="block text-xs font-medium text-slate-600">
-                        {col}
-                        <input
-                          class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
-                          value={columnDescriptions[name]?.[col] || ''}
-                          placeholder={`e.g. what the '${col}' column represents and its allowed values`}
-                          onInput={(e) => {
-                            const value = (e.target as HTMLInputElement).value;
-                            setColumnDescriptions((prev) => ({
-                              ...prev,
-                              [name]: { ...prev[name], [col]: value },
-                            }));
-                          }}
-                        />
-                      </label>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        ) : null}
-
         <label class="block text-xs font-medium text-slate-600">
           Category
           <select
@@ -741,6 +711,55 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
             onInput={(e) => setJoinKeyColumns((e.target as HTMLInputElement).value)}
           />
         </label>
+
+        {tableNames.length > 0 ? (
+          <div class="space-y-4 md:col-span-2">
+            {classifyError ? (
+              <div class="rounded-lg bg-red-50 p-2 text-xs text-red-700 ring-1 ring-red-200">{classifyError}</div>
+            ) : null}
+            {tableNames.map((name) => (
+              <div key={name} class="space-y-2 rounded-xl border border-slate-100 p-3">
+                <label class="block text-xs font-medium text-slate-600">
+                  <span>Table description — {name}</span>
+                  <textarea
+                    class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+                    rows={2}
+                    value={tableDescriptions[name] || ''}
+                    placeholder="e.g. State-level livestock population counts disaggregated by species, breed, sex, age group, utility, and locality."
+                    onInput={(e) =>
+                      setTableDescriptions((prev) => ({ ...prev, [name]: (e.target as HTMLTextAreaElement).value }))
+                    }
+                  />
+                </label>
+
+                {(columnsByTable[name] || []).length > 0 ? (
+                  <div class="space-y-1.5 pl-3">
+                    <p class="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                      Column descriptions — {name}
+                    </p>
+                    {(columnsByTable[name] || []).map((col) => (
+                      <label key={col} class="block text-xs font-medium text-slate-600">
+                        {col}
+                        <input
+                          class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+                          value={columnDescriptions[name]?.[col] || ''}
+                          placeholder={`e.g. what the '${col}' column represents and its allowed values`}
+                          onInput={(e) => {
+                            const value = (e.target as HTMLInputElement).value;
+                            setColumnDescriptions((prev) => ({
+                              ...prev,
+                              [name]: { ...prev[name], [col]: value },
+                            }));
+                          }}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
 
       <button
@@ -827,7 +846,7 @@ function DraftQueue() {
                 </div>
                 <div class="mt-1 text-xs text-slate-500">
                   {draft.llm_model_id || 'Deterministic (rule-based)'} · created by {draft.created_by}
-                  {draft.created_at ? ` · ${new Date(draft.created_at).toLocaleString()}` : ''}
+                  {draft.created_at ? ` · ${formatUtcTimestamp(draft.created_at)}` : ''}
                 </div>
               </div>
               <div class="flex items-center gap-3">

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -1,0 +1,631 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+import { ApiRequestError, api } from '../../lib/api';
+import type {
+  Collection,
+  DataOwner,
+  ManifestDraftDetail,
+  ManifestDraftStatus,
+  ManifestDraftSummary,
+  ValidationFinding,
+} from '../../lib/types';
+
+function statusClasses(status: ManifestDraftStatus) {
+  if (status === 'approved') return 'bg-emerald-50 text-emerald-700 ring-emerald-200';
+  if (status === 'rejected') return 'bg-red-50 text-red-700 ring-red-200';
+  if (status === 'flagged') return 'bg-amber-50 text-amber-700 ring-amber-200';
+  return 'bg-slate-100 text-slate-700 ring-slate-200';
+}
+
+function severityClasses(severity: string) {
+  if (severity === 'error') return 'bg-red-50 text-red-700 ring-red-200';
+  if (severity === 'warning') return 'bg-amber-50 text-amber-700 ring-amber-200';
+  return 'bg-emerald-50 text-emerald-700 ring-emerald-200';
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiRequestError) return err.message;
+  return err instanceof Error ? err.message : fallback;
+}
+
+function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [csvFiles, setCsvFiles] = useState<File[]>([]);
+  const [digitizationLogFile, setDigitizationLogFile] = useState<File | null>(null);
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [collectionsError, setCollectionsError] = useState('');
+  const [dataOwners, setDataOwners] = useState<DataOwner[]>([]);
+  const [dataOwnersError, setDataOwnersError] = useState('');
+  const [categoryId, setCategoryId] = useState('');
+  const [collectionId, setCollectionId] = useState('');
+  const [dataOwnerName, setDataOwnerName] = useState('');
+  const [datasetId, setDatasetId] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!open || collections.length > 0) return;
+    api
+      .getCollections()
+      .then((res) => setCollections(res.collections))
+      .catch((err) => setCollectionsError(errorMessage(err, 'Failed to load categories/collections')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || dataOwners.length > 0) return;
+    api
+      .getDataOwners()
+      .then((res) => setDataOwners(res.data_owners))
+      .catch((err) => setDataOwnersError(errorMessage(err, 'Failed to load data owners')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const categories = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const c of collections) seen.set(c.category_id, c.category_name);
+    return Array.from(seen.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  }, [collections]);
+
+  const collectionsForCategory = useMemo(
+    () => collections.filter((c) => c.category_id === categoryId).sort((a, b) => a.collection_name.localeCompare(b.collection_name)),
+    [collections, categoryId]
+  );
+
+  const submit = async (e: Event) => {
+    e.preventDefault();
+    if (csvFiles.length === 0 || !categoryId || !collectionId || !dataOwnerName) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await api.adminGenerateManifestDraft({
+        csvFiles,
+        categoryId,
+        collectionId,
+        dataOwnerName,
+        datasetId: datasetId || undefined,
+        digitizationLogFile,
+      });
+      setCsvFiles([]);
+      setDigitizationLogFile(null);
+      setCategoryId('');
+      setCollectionId('');
+      setDataOwnerName('');
+      setDatasetId('');
+      setOpen(false);
+      onGenerated();
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to generate draft'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800"
+      >
+        + Generate new draft
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} class="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold text-slate-900">Generate new draft</h3>
+        <button type="button" onClick={() => setOpen(false)} class="text-xs text-slate-400 hover:text-slate-600">
+          Cancel
+        </button>
+      </div>
+
+      {error ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{error}</div>
+      ) : null}
+      {collectionsError ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{collectionsError}</div>
+      ) : null}
+      {dataOwnersError ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{dataOwnersError}</div>
+      ) : null}
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="block text-xs font-medium text-slate-600">
+          Raw CSV(s) — select more than one for a multi-table dataset
+          <input
+            type="file"
+            accept=".csv"
+            multiple
+            class="mt-1 block w-full text-sm"
+            onChange={(e) => setCsvFiles(Array.from((e.target as HTMLInputElement).files ?? []))}
+          />
+          {csvFiles.length > 0 ? (
+            <span class="mt-1 block text-[11px] text-slate-500">
+              {csvFiles.length} table{csvFiles.length > 1 ? 's' : ''}: {csvFiles.map((f) => f.name).join(', ')}
+            </span>
+          ) : null}
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Digitization log (optional)
+          <input
+            type="file"
+            accept=".yaml,.yml"
+            class="mt-1 block w-full text-sm"
+            onChange={(e) => setDigitizationLogFile((e.target as HTMLInputElement).files?.[0] ?? null)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Category
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={categoryId}
+            onChange={(e) => {
+              setCategoryId((e.target as HTMLSelectElement).value);
+              setCollectionId('');
+            }}
+          >
+            <option value="">Select a category…</option>
+            {categories.map(([id, name]) => (
+              <option key={id} value={id}>
+                {name} ({id})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Collection
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={collectionId}
+            disabled={!categoryId}
+            onChange={(e) => setCollectionId((e.target as HTMLSelectElement).value)}
+          >
+            <option value="">{categoryId ? 'Select a collection…' : 'Select a category first'}</option>
+            {collectionsForCategory.map((c) => (
+              <option key={c.collection_id} value={c.collection_id}>
+                {c.collection_name} ({c.collection_id})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Data owner
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={dataOwnerName}
+            onChange={(e) => setDataOwnerName((e.target as HTMLSelectElement).value)}
+          >
+            <option value="">Select a data owner…</option>
+            {dataOwners.map((o) => (
+              <option key={o.id} value={o.name}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Existing dataset ID (optional — leave blank to auto-assign the next available ID)
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={datasetId}
+            onInput={(e) => setDatasetId((e.target as HTMLInputElement).value)}
+          />
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting || csvFiles.length === 0 || !categoryId || !collectionId || !dataOwnerName}
+        class="w-full rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+      >
+        {submitting ? 'Generating… (this calls the LLM, may take a moment)' : 'Generate draft'}
+      </button>
+    </form>
+  );
+}
+
+function DraftQueue() {
+  const [drafts, setDrafts] = useState<ManifestDraftSummary[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await api.adminListManifestDrafts(statusFilter ? { status: statusFilter } : undefined);
+      setDrafts(result.drafts);
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to load manifest drafts'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
+
+  return (
+    <div class="space-y-4">
+      <GenerateDraftForm onGenerated={load} />
+
+      <div class="flex flex-wrap items-center gap-2">
+        {['', 'pending', 'flagged', 'approved', 'rejected'].map((value) => (
+          <button
+            type="button"
+            key={value || 'all'}
+            onClick={() => setStatusFilter(value)}
+            class={`rounded-xl px-3 py-1.5 text-sm font-medium transition ${
+              statusFilter === value
+                ? 'bg-slate-900 text-white'
+                : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+            }`}
+          >
+            {value ? value[0].toUpperCase() + value.slice(1) : 'All'}
+          </button>
+        ))}
+      </div>
+
+      {error ? (
+        <div class="rounded-xl bg-red-50 p-4 text-sm text-red-700 ring-1 ring-red-200">{error}</div>
+      ) : null}
+
+      {loading ? (
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading…</div>
+      ) : drafts.length === 0 ? (
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
+          No drafts yet — use "Generate new draft" above, or run{' '}
+          <code class="rounded bg-slate-100 px-1.5 py-0.5">dataio draft generate</code> from the CLI.
+        </div>
+      ) : (
+        <div class="space-y-2">
+          {drafts.map((draft) => (
+            <a
+              key={draft.draft_id}
+              href={`/admin/datasets/drafts/view?id=${encodeURIComponent(draft.draft_id)}`}
+              class="flex items-center justify-between rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow"
+            >
+              <div>
+                <div class="font-medium text-slate-900">
+                  {draft.dataset_id || draft.collection_id}
+                </div>
+                <div class="mt-1 text-xs text-slate-500">
+                  {draft.llm_model_id} · created by {draft.created_by}
+                  {draft.created_at ? ` · ${new Date(draft.created_at).toLocaleString()}` : ''}
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <span class={`rounded-full px-3 py-1 text-xs font-medium ring-1 ${statusClasses(draft.status)}`}>
+                  {draft.status}
+                </span>
+                <button
+                  type="button"
+                  title="Delete draft"
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!window.confirm('Delete this draft permanently? This cannot be undone.')) return;
+                    await api.adminDeleteManifestDraft(draft.draft_id);
+                    load();
+                  }}
+                  class="rounded-lg px-2 py-1 text-xs font-medium text-red-500 hover:bg-red-50 hover:text-red-700"
+                >
+                  Delete
+                </button>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function findingRows(findings: ValidationFinding[] | undefined) {
+  if (!findings || findings.length === 0) return null;
+  return (
+    <div class="space-y-1.5">
+      {findings.map((finding, idx) => (
+        <div
+          key={idx}
+          class={`rounded-lg px-3 py-2 text-xs ring-1 ${severityClasses(finding.severity)}`}
+        >
+          <span class="font-semibold uppercase">{finding.severity}</span> {finding.message}
+          {finding.path ? <span class="opacity-70"> ({finding.path})</span> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DraftDetail({ draftId }: { draftId: string }) {
+  const [draft, setDraft] = useState<ManifestDraftDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [actionError, setActionError] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [flagFieldPath, setFlagFieldPath] = useState('');
+  const [flagNote, setFlagNote] = useState('');
+
+  const load = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await api.adminGetManifestDraft(draftId);
+      setDraft(result);
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to load manifest draft'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId]);
+
+  const runAction = async (action: () => Promise<unknown>) => {
+    setBusy(true);
+    setActionError('');
+    try {
+      await action();
+      await load();
+    } catch (err) {
+      setActionError(errorMessage(err, 'Action failed'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return <div class="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading…</div>;
+  }
+  if (error || !draft) {
+    return <div class="rounded-xl bg-red-50 p-4 text-sm text-red-700 ring-1 ring-red-200">{error || 'Draft not found'}</div>;
+  }
+
+  // dataset_id is always set (a reserved ID) - dataset_exists is what
+  // actually tells us whether that ID belongs to a real Dataset row yet.
+  const isNewDataset = draft.dataset_exists === false;
+
+  return (
+    <div class="space-y-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">
+            {draft.dataset_id}
+            {isNewDataset ? <span class="ml-2 text-sm font-normal text-slate-400">(new dataset — reserved ID)</span> : null}
+          </h2>
+          <p class="text-xs text-slate-500">
+            Model: {draft.llm_model_id} · Created by {draft.created_by}
+          </p>
+        </div>
+        <div class="flex items-center gap-3">
+          <span class={`rounded-full px-3 py-1 text-xs font-medium ring-1 ${statusClasses(draft.status)}`}>
+            {draft.status}
+          </span>
+          <button
+            type="button"
+            disabled={busy || draft.status === 'approved'}
+            onClick={() => runAction(() => api.adminApproveManifestDraft(draftId))}
+            class="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {draft.status === 'approved' ? 'Approved' : 'Approve'}
+          </button>
+          <button
+            type="button"
+            disabled={busy || draft.status === 'approved' || draft.status === 'rejected'}
+            onClick={() => {
+              const reason = window.prompt('Reason for rejecting this draft (optional):') ?? undefined;
+              runAction(() => api.adminRejectManifestDraft(draftId, reason || undefined));
+            }}
+            class="rounded-lg bg-white px-3 py-1.5 text-xs font-medium text-red-700 ring-1 ring-red-200 hover:bg-red-50 disabled:opacity-50"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            disabled={busy || draft.status === 'approved'}
+            onClick={async () => {
+              if (!window.confirm('Regenerate this draft from the same CSV(s)? The current draft will be marked rejected and superseded by a new one.')) return;
+              setBusy(true);
+              setActionError('');
+              try {
+                const result = await api.adminRegenerateManifestDraft(draftId);
+                window.location.href = `/admin/datasets/drafts/view?id=${encodeURIComponent(result.draft_id)}`;
+              } catch (err) {
+                setActionError(errorMessage(err, 'Failed to regenerate draft'));
+                setBusy(false);
+              }
+            }}
+            class="rounded-lg bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+          >
+            Regenerate
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const blob = new Blob([draft.draft_yaml], { type: 'application/x-yaml' });
+              const url = URL.createObjectURL(blob);
+              const link = document.createElement('a');
+              link.href = url;
+              link.download = `${draft.dataset_id || draft.collection_id}-metadata.yaml`;
+              link.click();
+              URL.revokeObjectURL(url);
+            }}
+            class="rounded-lg bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200"
+          >
+            Download YAML
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={async () => {
+              if (!window.confirm('Delete this draft permanently? This cannot be undone.')) return;
+              await api.adminDeleteManifestDraft(draftId);
+              window.location.href = '/admin/datasets/drafts';
+            }}
+            class="rounded-lg bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {isNewDataset ? (
+        <p class="text-xs text-slate-500">
+          Dataset ID <code class="rounded bg-slate-100 px-1 py-0.5">{draft.dataset_id}</code> is reserved (see the
+          "Reserved IDs" tab) and stays reserved until this dataset is actually imported/uploaded.
+        </p>
+      ) : null}
+
+      {actionError ? (
+        <div class="rounded-xl bg-red-50 p-4 text-sm text-red-700 ring-1 ring-red-200">{actionError}</div>
+      ) : null}
+
+      {draft.flagged_fields.length > 0 ? (
+        <div class="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+          <h3 class="text-sm font-semibold text-amber-900">Flagged by the drafter</h3>
+          <ul class="mt-2 space-y-1 text-sm text-amber-800">
+            {draft.flagged_fields.map((f, idx) => (
+              <li key={idx}>
+                <span class="font-medium">{f.field}</span>: {f.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {draft.reviewer_notes.length > 0 ? (
+        <div class="rounded-2xl border border-slate-200 bg-white p-4">
+          <h3 class="text-sm font-semibold text-slate-900">Reviewer notes</h3>
+          <ul class="mt-2 space-y-1 text-sm text-slate-600">
+            {draft.reviewer_notes.map((n, idx) => (
+              <li key={idx}>
+                {n.field ? <span class="font-medium">{n.field}: </span> : null}
+                {n.note} <span class="text-xs text-slate-400">— {n.by}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <h3 class="text-sm font-semibold text-slate-900">Flag a field</h3>
+        <p class="mt-1 text-xs text-slate-500">
+          Mark a specific field as needing attention (e.g. a value the drafter got wrong) - sets the draft's status
+          to "flagged" and records this note for the next reviewer.
+        </p>
+        <form
+          class="mt-3 flex flex-wrap items-end gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!flagFieldPath.trim() || !flagNote.trim()) return;
+            runAction(() => api.adminFlagManifestDraftField(draftId, flagFieldPath.trim(), flagNote.trim())).then(
+              () => {
+                setFlagFieldPath('');
+                setFlagNote('');
+              }
+            );
+          }}
+        >
+          <label class="block text-xs font-medium text-slate-600">
+            Field path
+            <input
+              class="mt-1 w-40 rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+              placeholder="e.g. sourceTableID"
+              value={flagFieldPath}
+              onInput={(e) => setFlagFieldPath((e.target as HTMLInputElement).value)}
+            />
+          </label>
+          <label class="block flex-1 text-xs font-medium text-slate-600">
+            Note
+            <input
+              class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+              placeholder="Why this field needs attention"
+              value={flagNote}
+              onInput={(e) => setFlagNote((e.target as HTMLInputElement).value)}
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={busy || !flagFieldPath.trim() || !flagNote.trim()}
+            class="rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+          >
+            Flag field
+          </button>
+        </form>
+      </div>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <div class="mb-2 flex items-center justify-between">
+          <h3 class="text-sm font-semibold text-slate-900">Draft manifest.yaml</h3>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => runAction(() => api.adminValidateManifestDraft(draftId))}
+            class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+          >
+            Re-validate
+          </button>
+        </div>
+        <pre class="max-h-96 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">{draft.draft_yaml}</pre>
+      </div>
+
+      {draft.validation_result ? (
+        <div class="rounded-2xl border border-slate-200 bg-white p-4">
+          <h3 class="mb-2 text-sm font-semibold text-slate-900">
+            Validation:{' '}
+            <span
+              class={`rounded px-2 py-0.5 text-xs ring-1 ${severityClasses(
+                draft.validation_result.status === 'fail'
+                  ? 'error'
+                  : draft.validation_result.status === 'warn'
+                    ? 'warning'
+                    : 'info'
+              )}`}
+            >
+              {draft.validation_result.status}
+            </span>
+          </h3>
+          {findingRows(draft.validation_result.findings)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function DraftReviewManager() {
+  return <DraftQueue />;
+}
+
+/**
+ * The site is built with `output: 'static'`, so there's no server-side
+ * dynamic route for a per-draft page - the draft id comes from a query
+ * param (?id=...) read client-side, the same way the rest of this static
+ * site handles anything that isn't known at build time.
+ */
+export function DraftReviewDetail() {
+  const [draftId, setDraftId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setDraftId(params.get('id'));
+  }, []);
+
+  if (!draftId) {
+    return (
+      <div class="rounded-xl bg-red-50 p-4 text-sm text-red-700 ring-1 ring-red-200">
+        No draft id in the URL (expected ?id=&lt;draft-id&gt;).
+      </div>
+    );
+  }
+  return <DraftDetail draftId={draftId} />;
+}

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -1,14 +1,28 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
+import { stringify as stringifyYaml } from 'yaml';
 
 import { ApiRequestError, api } from '../../lib/api';
 import type {
   Collection,
+  CuratorMetadataInput,
   DataOwner,
   ManifestDraftDetail,
   ManifestDraftStatus,
   ManifestDraftSummary,
   ValidationFinding,
 } from '../../lib/types';
+
+function csvToList(text: string): string[] {
+  return text
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+async function readCsvHeaderColumns(file: File): Promise<string[]> {
+  const headerLine = (await file.text()).split(/\r?\n/, 1)[0] ?? '';
+  return headerLine.split(',').map((c) => c.trim()).filter(Boolean);
+}
 
 function statusClasses(status: ManifestDraftStatus) {
   if (status === 'approved') return 'bg-emerald-50 text-emerald-700 ring-emerald-200';
@@ -114,7 +128,7 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
   }
 
   return (
-    <form onSubmit={submit} class="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+    <form onSubmit={submit} class="w-full space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
       <div class="flex items-center justify-between">
         <h3 class="text-sm font-semibold text-slate-900">Generate new draft</h3>
         <button type="button" onClick={() => setOpen(false)} class="text-xs text-slate-400 hover:text-slate-600">
@@ -227,6 +241,519 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
   );
 }
 
+function RepeatableTextList({
+  label,
+  values,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div class="block text-xs font-medium text-slate-600">
+      {label}
+      <div class="mt-1 space-y-1.5">
+        {values.map((value, idx) => (
+          <div key={idx} class="flex gap-1.5">
+            <textarea
+              class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm font-normal"
+              rows={2}
+              value={value}
+              placeholder={placeholder}
+              onInput={(e) => {
+                const next = [...values];
+                next[idx] = (e.target as HTMLTextAreaElement).value;
+                onChange(next);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => onChange(values.filter((_, i) => i !== idx))}
+              class="shrink-0 rounded-lg px-2 text-xs text-slate-400 hover:text-red-600"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange([...values, ''])}
+          class="rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-700 hover:bg-slate-200"
+        >
+          + Add entry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [csvFiles, setCsvFiles] = useState<File[]>([]);
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [collectionsError, setCollectionsError] = useState('');
+  const [dataOwners, setDataOwners] = useState<DataOwner[]>([]);
+  const [dataOwnersError, setDataOwnersError] = useState('');
+  const [categoryId, setCategoryId] = useState('');
+  const [collectionId, setCollectionId] = useState('');
+  const [dataOwnerName, setDataOwnerName] = useState('');
+  const [datasetId, setDatasetId] = useState('');
+  const [datasetTitle, setDatasetTitle] = useState('');
+  const [datasetDescription, setDatasetDescription] = useState('');
+  const [source, setSource] = useState<string[]>([]);
+  const [references, setReferences] = useState<string[]>([]);
+  const [tagsConcept, setTagsConcept] = useState('');
+  const [tagsEpiType, setTagsEpiType] = useState('');
+  const [spatialCoverage, setSpatialCoverage] = useState('');
+  const [spatialResolution, setSpatialResolution] = useState('');
+  const [temporalCoverage, setTemporalCoverage] = useState('');
+  const [temporalResolution, setTemporalResolution] = useState('');
+  const [updateFrequency, setUpdateFrequency] = useState('');
+  const [comments, setComments] = useState<string[]>([]);
+  const [joinKeyColumns, setJoinKeyColumns] = useState('');
+  const [tableDescriptions, setTableDescriptions] = useState<Record<string, string>>({});
+  const [columnsByTable, setColumnsByTable] = useState<Record<string, string[]>>({});
+  const [columnDescriptions, setColumnDescriptions] = useState<Record<string, Record<string, string>>>({});
+  const [classifyError, setClassifyError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const tableNames = useMemo(() => csvFiles.map((f) => f.name.replace(/\.csv$/i, '')), [csvFiles]);
+
+  useEffect(() => {
+    if (csvFiles.length === 0) {
+      setColumnsByTable({});
+      return;
+    }
+    let cancelled = false;
+    setClassifyError('');
+    Promise.all(
+      csvFiles.map(async (file, idx) => {
+        const tableName = tableNames[idx];
+        const columnNames = await readCsvHeaderColumns(file);
+        const { needsDescription } = await api.adminClassifyColumns({ tableName, columnNames });
+        return [tableName, needsDescription] as const;
+      })
+    )
+      .then((entries) => {
+        if (!cancelled) setColumnsByTable(Object.fromEntries(entries));
+      })
+      .catch((err) => {
+        if (!cancelled) setClassifyError(errorMessage(err, 'Failed to classify CSV columns'));
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [csvFiles]);
+
+  useEffect(() => {
+    if (!open || collections.length > 0) return;
+    api
+      .getCollections()
+      .then((res) => setCollections(res.collections))
+      .catch((err) => setCollectionsError(errorMessage(err, 'Failed to load categories/collections')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || dataOwners.length > 0) return;
+    api
+      .getDataOwners()
+      .then((res) => setDataOwners(res.data_owners))
+      .catch((err) => setDataOwnersError(errorMessage(err, 'Failed to load data owners')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const categories = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const c of collections) seen.set(c.category_id, c.category_name);
+    return Array.from(seen.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  }, [collections]);
+
+  const collectionsForCategory = useMemo(
+    () => collections.filter((c) => c.category_id === categoryId).sort((a, b) => a.collection_name.localeCompare(b.collection_name)),
+    [collections, categoryId]
+  );
+
+  const requiredFieldsFilled =
+    csvFiles.length > 0 &&
+    categoryId &&
+    collectionId &&
+    dataOwnerName &&
+    (csvFiles.length === 1 || datasetTitle.trim()) &&
+    datasetDescription &&
+    spatialCoverage &&
+    spatialResolution &&
+    temporalCoverage &&
+    temporalResolution &&
+    updateFrequency &&
+    tableNames.every((name) => (tableDescriptions[name] || '').trim()) &&
+    tableNames.every((name) =>
+      (columnsByTable[name] || []).every((col) => (columnDescriptions[name]?.[col] || '').trim())
+    );
+
+  const submit = async (e: Event) => {
+    e.preventDefault();
+    if (!requiredFieldsFilled) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const curatorInput: CuratorMetadataInput = {
+        datasetTitle: datasetTitle.trim(),
+        datasetDescription,
+        source: source.map((s) => s.trim()).filter(Boolean),
+        references: references.map((r) => r.trim()).filter(Boolean),
+        tags: { concept: csvToList(tagsConcept), epiType: csvToList(tagsEpiType) },
+        spatialCoverage,
+        spatialResolution,
+        temporalCoverage,
+        temporalResolution,
+        updateFrequency,
+        comments: comments.map((c) => c.trim()).filter(Boolean),
+        joinKeyColumns: csvToList(joinKeyColumns),
+        tableDescriptions: Object.fromEntries(tableNames.map((name) => [name, tableDescriptions[name] || ''])),
+        columnDescriptions: Object.fromEntries(
+          tableNames.map((name) => [
+            name,
+            Object.fromEntries(
+              (columnsByTable[name] || []).map((col) => [col, columnDescriptions[name]?.[col] || ''])
+            ),
+          ])
+        ),
+      };
+      await api.adminGenerateDeterministicManifestDraft({
+        csvFiles,
+        categoryId,
+        collectionId,
+        dataOwnerName,
+        curatorInput,
+        datasetId: datasetId || undefined,
+      });
+      setCsvFiles([]);
+      setCategoryId('');
+      setCollectionId('');
+      setDataOwnerName('');
+      setDatasetId('');
+      setDatasetTitle('');
+      setDatasetDescription('');
+      setSource([]);
+      setReferences([]);
+      setTagsConcept('');
+      setTagsEpiType('');
+      setSpatialCoverage('');
+      setSpatialResolution('');
+      setTemporalCoverage('');
+      setTemporalResolution('');
+      setUpdateFrequency('');
+      setComments([]);
+      setJoinKeyColumns('');
+      setTableDescriptions({});
+      setColumnsByTable({});
+      setColumnDescriptions({});
+      setOpen(false);
+      onGenerated();
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to generate deterministic draft'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        class="rounded-xl bg-white px-4 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-300 hover:bg-slate-50"
+      >
+        + Generate deterministic draft (no LLM)
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} class="w-full space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-sm font-semibold text-slate-900">Generate deterministic draft</h3>
+          <p class="text-xs text-slate-500">
+            Rule-based typing + curated region history - no CSV content is sent anywhere. Fields below can't be
+            inferred from the data and must be supplied directly.
+          </p>
+        </div>
+        <button type="button" onClick={() => setOpen(false)} class="text-xs text-slate-400 hover:text-slate-600">
+          Cancel
+        </button>
+      </div>
+
+      {error ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{error}</div>
+      ) : null}
+      {collectionsError ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{collectionsError}</div>
+      ) : null}
+      {dataOwnersError ? (
+        <div class="rounded-lg bg-red-50 p-3 text-xs text-red-700 ring-1 ring-red-200">{dataOwnersError}</div>
+      ) : null}
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="block text-xs font-medium text-slate-600 md:col-span-2">
+          Raw CSV(s) — select more than one for a multi-table dataset
+          <input
+            type="file"
+            accept=".csv"
+            multiple
+            class="mt-1 block w-full text-sm"
+            onChange={(e) => setCsvFiles(Array.from((e.target as HTMLInputElement).files ?? []))}
+          />
+          {csvFiles.length > 0 ? (
+            <span class="mt-1 block text-[11px] text-slate-500">
+              {csvFiles.length} table{csvFiles.length > 1 ? 's' : ''}: {csvFiles.map((f) => f.name).join(', ')}
+            </span>
+          ) : null}
+        </label>
+
+        {tableNames.length > 0 ? (
+          <div class="space-y-4 md:col-span-2">
+            {classifyError ? (
+              <div class="rounded-lg bg-red-50 p-2 text-xs text-red-700 ring-1 ring-red-200">{classifyError}</div>
+            ) : null}
+            {tableNames.map((name) => (
+              <div key={name} class="space-y-2 rounded-xl border border-slate-100 p-3">
+                <label class="block text-xs font-medium text-slate-600">
+                  <span>Table description — {name}</span>
+                  <textarea
+                    class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+                    rows={2}
+                    value={tableDescriptions[name] || ''}
+                    placeholder="e.g. State-level livestock population counts disaggregated by species, breed, sex, age group, utility, and locality."
+                    onInput={(e) =>
+                      setTableDescriptions((prev) => ({ ...prev, [name]: (e.target as HTMLTextAreaElement).value }))
+                    }
+                  />
+                </label>
+
+                {(columnsByTable[name] || []).length > 0 ? (
+                  <div class="space-y-1.5 pl-3">
+                    <p class="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                      Column descriptions — {name}
+                    </p>
+                    {(columnsByTable[name] || []).map((col) => (
+                      <label key={col} class="block text-xs font-medium text-slate-600">
+                        {col}
+                        <input
+                          class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+                          value={columnDescriptions[name]?.[col] || ''}
+                          placeholder={`e.g. what the '${col}' column represents and its allowed values`}
+                          onInput={(e) => {
+                            const value = (e.target as HTMLInputElement).value;
+                            setColumnDescriptions((prev) => ({
+                              ...prev,
+                              [name]: { ...prev[name], [col]: value },
+                            }));
+                          }}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <label class="block text-xs font-medium text-slate-600">
+          Category
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={categoryId}
+            onChange={(e) => {
+              setCategoryId((e.target as HTMLSelectElement).value);
+              setCollectionId('');
+            }}
+          >
+            <option value="">Select a category…</option>
+            {categories.map(([id, name]) => (
+              <option key={id} value={id}>
+                {name} ({id})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Collection
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={collectionId}
+            disabled={!categoryId}
+            onChange={(e) => setCollectionId((e.target as HTMLSelectElement).value)}
+          >
+            <option value="">{categoryId ? 'Select a collection…' : 'Select a category first'}</option>
+            {collectionsForCategory.map((c) => (
+              <option key={c.collection_id} value={c.collection_id}>
+                {c.collection_name} ({c.collection_id})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Data owner
+          <select
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={dataOwnerName}
+            onChange={(e) => setDataOwnerName((e.target as HTMLSelectElement).value)}
+          >
+            <option value="">Select a data owner…</option>
+            {dataOwners.map((o) => (
+              <option key={o.id} value={o.name}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Existing dataset ID (optional — leave blank to auto-assign the next available ID)
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={datasetId}
+            onInput={(e) => setDatasetId((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        {csvFiles.length > 1 ? (
+          <label class="block text-xs font-medium text-slate-600 md:col-span-2">
+            Dataset title — required with multiple CSVs (a single CSV is always named after its own filename)
+            <input
+              class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+              value={datasetTitle}
+              placeholder="e.g. bahs-milk-production-statistics-1950-2024"
+              onInput={(e) => setDatasetTitle((e.target as HTMLInputElement).value)}
+            />
+          </label>
+        ) : null}
+
+        <label class="block text-xs font-medium text-slate-600 md:col-span-2">
+          Dataset description
+          <textarea
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            rows={2}
+            value={datasetDescription}
+            placeholder="e.g. State-level livestock population counts disaggregated by species, breed, sex, age group, utility, and locality."
+            onInput={(e) => setDatasetDescription((e.target as HTMLTextAreaElement).value)}
+          />
+        </label>
+        <div class="md:col-span-2">
+          <RepeatableTextList
+            label="Source document(s) — optional, one citation per entry"
+            values={source}
+            onChange={setSource}
+            placeholder="e.g. 16th Livestock Census 1997 – Department of Animal Husbandry, Dairying & Fisheries, Government of India"
+          />
+        </div>
+        <div class="md:col-span-2">
+          <RepeatableTextList
+            label="References / URLs — optional, one per entry"
+            values={references}
+            onChange={setReferences}
+            placeholder="e.g. https://dahd.gov.in/sites/default/files/2019-12/16thLivestockCensusBook.pdf"
+          />
+        </div>
+        <label class="block text-xs font-medium text-slate-600">
+          Tags — concept (comma-separated)
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={tagsConcept}
+            placeholder="e.g. livestock, cattle, buffalo"
+            onInput={(e) => setTagsConcept((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Tags — epiType (comma-separated)
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={tagsEpiType}
+            placeholder="e.g. population"
+            onInput={(e) => setTagsEpiType((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Spatial coverage
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={spatialCoverage}
+            placeholder="e.g. india"
+            onInput={(e) => setSpatialCoverage((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Spatial resolution
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={spatialResolution}
+            placeholder="e.g. state"
+            onInput={(e) => setSpatialResolution((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Temporal coverage
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={temporalCoverage}
+            placeholder="e.g. 1997, 2003, 2007, 2012, 2019"
+            onInput={(e) => setTemporalCoverage((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Temporal resolution
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={temporalResolution}
+            placeholder="e.g. quinquennial"
+            onInput={(e) => setTemporalResolution((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="block text-xs font-medium text-slate-600">
+          Update frequency
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={updateFrequency}
+            placeholder="e.g. quinquennial"
+            onInput={(e) => setUpdateFrequency((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <div class="md:col-span-2">
+          <RepeatableTextList
+            label="Comments — optional analyst notes, one per entry (region-history notes are added automatically, no need to repeat them here)"
+            values={comments}
+            onChange={setComments}
+            placeholder="e.g. The 'total' locality row equals rural + urban exactly for every observation."
+          />
+        </div>
+        <label class="block text-xs font-medium text-slate-600 md:col-span-2">
+          Join key columns (comma-separated, optional — leave blank to accept the auto-suggested candidates)
+          <input
+            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={joinKeyColumns}
+            placeholder="e.g. state.ID, year"
+            onInput={(e) => setJoinKeyColumns((e.target as HTMLInputElement).value)}
+          />
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting || !requiredFieldsFilled}
+        class="w-full rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+      >
+        {submitting ? 'Generating…' : 'Generate deterministic draft'}
+      </button>
+    </form>
+  );
+}
+
 function DraftQueue() {
   const [drafts, setDrafts] = useState<ManifestDraftSummary[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -253,7 +780,10 @@ function DraftQueue() {
 
   return (
     <div class="space-y-4">
-      <GenerateDraftForm onGenerated={load} />
+      <div class="flex flex-col items-start gap-2">
+        <GenerateDraftForm onGenerated={load} />
+        <GenerateDeterministicDraftForm onGenerated={load} />
+      </div>
 
       <div class="flex flex-wrap items-center gap-2">
         {['', 'pending', 'flagged', 'approved', 'rejected'].map((value) => (
@@ -296,7 +826,7 @@ function DraftQueue() {
                   {draft.dataset_id || draft.collection_id}
                 </div>
                 <div class="mt-1 text-xs text-slate-500">
-                  {draft.llm_model_id} · created by {draft.created_by}
+                  {draft.llm_model_id || 'Deterministic (rule-based)'} · created by {draft.created_by}
                   {draft.created_at ? ` · ${new Date(draft.created_at).toLocaleString()}` : ''}
                 </div>
               </div>
@@ -344,6 +874,38 @@ function findingRows(findings: ValidationFinding[] | undefined) {
   );
 }
 
+interface NumericFieldEntry {
+  table: string;
+  column: string;
+  additive: boolean;
+  min: string;
+}
+
+// Every non-join-key int/float data_dictionary column across all tables -
+// additive/aggregation/min aren't safely inferable by rule (a rate or an ID
+// isn't summable just because it's numeric), so this surfaces them here for
+// the curator to opt into per column, post-generation. Reads only
+// draft_json already on the client - no CSV, no network, no AI.
+function extractNumericFields(draftJson: Record<string, unknown>): NumericFieldEntry[] {
+  const tables = (draftJson.tables as Record<string, unknown>) || {};
+  const entries: NumericFieldEntry[] = [];
+  for (const [tableName, table] of Object.entries(tables)) {
+    const dataDictionary =
+      ((table as Record<string, unknown>)?.data_dictionary as Record<string, Record<string, unknown>>) || {};
+    for (const [columnName, field] of Object.entries(dataDictionary)) {
+      if ((field.type !== 'int' && field.type !== 'float') || field.isJoinKey) continue;
+      if (columnName.toLowerCase().startsWith('source')) continue; // provenance, e.g. sourcePage - never a measure
+      entries.push({
+        table: tableName,
+        column: columnName,
+        additive: field.additive === true,
+        min: field.min === undefined || field.min === null ? '' : String(field.min),
+      });
+    }
+  }
+  return entries;
+}
+
 function DraftDetail({ draftId }: { draftId: string }) {
   const [draft, setDraft] = useState<ManifestDraftDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -352,6 +914,9 @@ function DraftDetail({ draftId }: { draftId: string }) {
   const [busy, setBusy] = useState(false);
   const [flagFieldPath, setFlagFieldPath] = useState('');
   const [flagNote, setFlagNote] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [editedYaml, setEditedYaml] = useState('');
+  const [numericFields, setNumericFields] = useState<NumericFieldEntry[]>([]);
 
   const load = async () => {
     setLoading(true);
@@ -359,6 +924,7 @@ function DraftDetail({ draftId }: { draftId: string }) {
     try {
       const result = await api.adminGetManifestDraft(draftId);
       setDraft(result);
+      setNumericFields(extractNumericFields(result.draft_json));
     } catch (err) {
       setError(errorMessage(err, 'Failed to load manifest draft'));
     } finally {
@@ -384,6 +950,32 @@ function DraftDetail({ draftId }: { draftId: string }) {
     }
   };
 
+  const applyNumericFieldSettings = () => {
+    if (!draft) return;
+    runAction(async () => {
+      const updated = JSON.parse(JSON.stringify(draft.draft_json)) as Record<string, any>;
+      for (const entry of numericFields) {
+        const field = updated.tables?.[entry.table]?.data_dictionary?.[entry.column];
+        if (!field) continue;
+        if (entry.additive) {
+          field.additive = true;
+          field.aggregation = 'sum';
+          const min = entry.min.trim();
+          if (min !== '' && !Number.isNaN(Number(min))) {
+            field.min = Number(min);
+          } else {
+            delete field.min;
+          }
+        } else {
+          delete field.additive;
+          delete field.aggregation;
+          delete field.min;
+        }
+      }
+      await api.adminUpdateManifestDraftContent(draftId, stringifyYaml(updated));
+    });
+  };
+
   if (loading) {
     return <div class="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading…</div>;
   }
@@ -397,17 +989,17 @@ function DraftDetail({ draftId }: { draftId: string }) {
 
   return (
     <div class="space-y-6">
-      <div class="flex items-center justify-between">
+      <div class="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 class="text-lg font-semibold text-slate-900">
             {draft.dataset_id}
             {isNewDataset ? <span class="ml-2 text-sm font-normal text-slate-400">(new dataset — reserved ID)</span> : null}
           </h2>
           <p class="text-xs text-slate-500">
-            Model: {draft.llm_model_id} · Created by {draft.created_by}
+            Model: {draft.llm_model_id || 'Deterministic (rule-based)'} · Created by {draft.created_by}
           </p>
         </div>
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-2">
           <span class={`rounded-full px-3 py-1 text-xs font-medium ring-1 ${statusClasses(draft.status)}`}>
             {draft.status}
           </span>
@@ -564,19 +1156,129 @@ function DraftDetail({ draftId }: { draftId: string }) {
         </form>
       </div>
 
+      {numericFields.length > 0 ? (
+        <div class="rounded-2xl border border-slate-200 bg-white p-4">
+          <div class="mb-2 flex items-center justify-between">
+            <div>
+              <h3 class="text-sm font-semibold text-slate-900">Numeric field settings</h3>
+              <p class="mt-1 text-xs text-slate-500">
+                Whether a numeric column can be summed across rows isn't safe to guess (a rate or an ID isn't
+                summable just because it's a number) - tick "Additive" only for columns that genuinely are, e.g. a
+                head-count. Unchecked columns are left exactly as generated.
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={busy || draft.status === 'approved' || draft.status === 'rejected'}
+              onClick={applyNumericFieldSettings}
+              class="shrink-0 rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+            >
+              Apply
+            </button>
+          </div>
+          <div class="space-y-1.5">
+            {numericFields.map((entry, idx) => (
+              <div key={`${entry.table}.${entry.column}`} class="flex items-center gap-3 text-xs text-slate-600">
+                <label class="flex items-center gap-1.5">
+                  <input
+                    type="checkbox"
+                    checked={entry.additive}
+                    disabled={draft.status === 'approved' || draft.status === 'rejected'}
+                    onChange={(e) => {
+                      const checked = (e.target as HTMLInputElement).checked;
+                      setNumericFields((prev) =>
+                        prev.map((f, i) => (i === idx ? { ...f, additive: checked } : f))
+                      );
+                    }}
+                  />
+                  <span class="font-medium text-slate-700">
+                    {entry.table}.{entry.column}
+                  </span>
+                  additive (summable)?
+                </label>
+                {entry.additive ? (
+                  <label class="flex items-center gap-1.5">
+                    min
+                    <input
+                      type="number"
+                      value={entry.min}
+                      placeholder="e.g. 0"
+                      class="w-20 rounded-lg border border-slate-300 px-2 py-1 text-xs"
+                      onInput={(e) => {
+                        const value = (e.target as HTMLInputElement).value;
+                        setNumericFields((prev) => prev.map((f, i) => (i === idx ? { ...f, min: value } : f)));
+                      }}
+                    />
+                  </label>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <div class="rounded-2xl border border-slate-200 bg-white p-4">
         <div class="mb-2 flex items-center justify-between">
           <h3 class="text-sm font-semibold text-slate-900">Draft manifest.yaml</h3>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => runAction(() => api.adminValidateManifestDraft(draftId))}
-            class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
-          >
-            Re-validate
-          </button>
+          <div class="flex items-center gap-2">
+            {editing ? (
+              <>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setEditing(false)}
+                  class="rounded-lg bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() =>
+                    runAction(async () => {
+                      await api.adminUpdateManifestDraftContent(draftId, editedYaml);
+                      setEditing(false);
+                    })
+                  }
+                  class="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  Save & re-validate
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  disabled={busy || draft.status === 'approved' || draft.status === 'rejected'}
+                  onClick={() => {
+                    setEditedYaml(draft.draft_yaml);
+                    setEditing(true);
+                  }}
+                  class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => runAction(() => api.adminValidateManifestDraft(draftId))}
+                  class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+                >
+                  Re-validate
+                </button>
+              </>
+            )}
+          </div>
         </div>
-        <pre class="max-h-96 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">{draft.draft_yaml}</pre>
+        {editing ? (
+          <textarea
+            class="h-96 w-full rounded-xl border border-slate-300 bg-slate-950 p-4 font-mono text-xs text-slate-100"
+            value={editedYaml}
+            onInput={(e) => setEditedYaml((e.target as HTMLTextAreaElement).value)}
+          />
+        ) : (
+          <pre class="max-h-96 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">{draft.draft_yaml}</pre>
+        )}
       </div>
 
       {draft.validation_result ? (

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -75,15 +75,7 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
   const [dataOwnerName, setDataOwnerName] = useState('');
   const [datasetId, setDatasetId] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [error, setError] = useState('');
-
-  useEffect(() => {
-    if (!submitting) return;
-    setElapsedSeconds(0);
-    const interval = setInterval(() => setElapsedSeconds((s) => s + 1), 1000);
-    return () => clearInterval(interval);
-  }, [submitting]);
 
   useEffect(() => {
     if (!open || collections.length > 0) return;
@@ -263,25 +255,8 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
         disabled={submitting || csvFiles.length === 0 || !categoryId || !collectionId || !dataOwnerName}
         class="w-full rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
       >
-        {submitting ? 'Generating…' : 'Generate draft'}
+        {submitting ? 'Generating… (this calls the LLM, may take a moment)' : 'Generate draft'}
       </button>
-      {submitting ? (
-        <div class="space-y-1.5">
-          <div class="h-1.5 w-full overflow-hidden rounded-full bg-emerald-100">
-            <div class="h-full w-1/3 animate-[llm-progress_1.4s_ease-in-out_infinite] rounded-full bg-emerald-500" />
-          </div>
-          <p class="text-center text-[11px] text-slate-500">
-            Calling the LLM — this reads the full CSV(s), so it can take a while. {elapsedSeconds}s elapsed…
-          </p>
-        </div>
-      ) : null}
-      <style>{`
-        @keyframes llm-progress {
-          0% { margin-left: 0%; }
-          50% { margin-left: 67%; }
-          100% { margin-left: 0%; }
-        }
-      `}</style>
     </form>
   );
 }

--- a/web/src/components/admin/DraftReviewManager.tsx
+++ b/web/src/components/admin/DraftReviewManager.tsx
@@ -261,20 +261,133 @@ function GenerateDraftForm({ onGenerated }: { onGenerated: () => void }) {
   );
 }
 
+function FieldHint({ text }: { text: string }) {
+  return (
+    <span
+      title={text}
+      class="ml-1 inline-flex h-3.5 w-3.5 shrink-0 cursor-help items-center justify-center rounded-full bg-slate-200 text-[9px] font-bold leading-none text-slate-500 hover:bg-slate-300"
+    >
+      ?
+    </span>
+  );
+}
+
+function AutoDetectedBadge() {
+  return (
+    <span
+      title="Filled in automatically from the uploaded CSV(s) - please check it's right, and edit it if not."
+      class="ml-1.5 shrink-0 rounded bg-emerald-50 px-1 py-0.5 text-[9px] font-medium leading-none text-emerald-600 ring-1 ring-emerald-200"
+    >
+      auto-detected — verify
+    </span>
+  );
+}
+
+// Predefined options are drawn from what real ARTPARK datasets actually use
+// (checked across data/*/metadata.yaml) - "Other" stays available since a
+// few real datasets use genuinely bespoke phrasing (e.g. "Survey-round
+// basis (not annual)") that a closed dropdown would otherwise block.
+const OTHER_OPTION = '__other__';
+const TEMPORAL_RESOLUTION_OPTIONS = [
+  'Annual', 'Quinquennial', 'Decadal', 'Monthly', 'Weekly', 'Daily', 'Semester',
+  'Survey round (single cross-section)',
+];
+const UPDATE_FREQUENCY_OPTIONS = [
+  'One-time', 'Annual', 'Quinquennial', 'Biannual', 'Monthly', 'Weekly', 'Daily', 'Adhoc',
+];
+
+function PresetSelectField({
+  label,
+  hint,
+  value,
+  onChange,
+  options,
+  placeholder,
+}: {
+  label: string;
+  hint: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder: string;
+}) {
+  // Computed once at mount - this component is inside a form that fully
+  // unmounts on close/reopen (see GenerateDeterministicDraftForm's `if
+  // (!open) return ...` early return), so there's no stale-value case to
+  // reconcile after a submit-triggered reset.
+  const [customMode, setCustomMode] = useState(value !== '' && !options.includes(value));
+
+  return (
+    <label class="block text-xs font-medium text-slate-600">
+      <span class="inline-flex items-center">
+        {label}
+        <FieldHint text={hint} />
+      </span>
+      {customMode ? (
+        <div class="mt-1 flex gap-1.5">
+          <input
+            class="w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+            value={value}
+            placeholder={placeholder}
+            onInput={(e) => onChange((e.target as HTMLInputElement).value)}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setCustomMode(false);
+              onChange('');
+            }}
+            class="shrink-0 rounded-lg px-2 text-[11px] font-medium text-slate-500 hover:text-slate-700"
+          >
+            Use list
+          </button>
+        </div>
+      ) : (
+        <select
+          class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
+          value={value}
+          onChange={(e) => {
+            const next = (e.target as HTMLSelectElement).value;
+            if (next === OTHER_OPTION) {
+              setCustomMode(true);
+              onChange('');
+            } else {
+              onChange(next);
+            }
+          }}
+        >
+          <option value="">Select…</option>
+          {options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+          <option value={OTHER_OPTION}>Other (type my own)…</option>
+        </select>
+      )}
+    </label>
+  );
+}
+
 function RepeatableTextList({
   label,
+  hint,
   values,
   onChange,
   placeholder,
 }: {
   label: string;
+  hint?: string;
   values: string[];
   onChange: (values: string[]) => void;
   placeholder?: string;
 }) {
   return (
     <div class="block text-xs font-medium text-slate-600">
-      {label}
+      <span class="inline-flex items-center">
+        {label}
+        {hint ? <FieldHint text={hint} /> : null}
+      </span>
       <div class="mt-1 space-y-1.5">
         {values.map((value, idx) => (
           <div key={idx} class="flex gap-1.5">
@@ -338,8 +451,14 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
   const [columnsByTable, setColumnsByTable] = useState<Record<string, string[]>>({});
   const [columnDescriptions, setColumnDescriptions] = useState<Record<string, Record<string, string>>>({});
   const [classifyError, setClassifyError] = useState('');
+  const [coverageAutoFilled, setCoverageAutoFilled] = useState<Record<string, boolean>>({});
+  const [coverageInferError, setCoverageInferError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+
+  const clearAutoFilled = (field: string) => {
+    setCoverageAutoFilled((prev) => (prev[field] ? { ...prev, [field]: false } : prev));
+  };
 
   const tableNames = useMemo(() => csvFiles.map((f) => f.name.replace(/\.csv$/i, '')), [csvFiles]);
 
@@ -363,6 +482,49 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
       })
       .catch((err) => {
         if (!cancelled) setClassifyError(errorMessage(err, 'Failed to classify CSV columns'));
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [csvFiles]);
+
+  // Auto-detects spatialCoverage/spatialResolution/temporalCoverage from
+  // the CSVs' own column names/values (e.g. a "state.name" column implies
+  // India + state-level; a year-typed column's observed values become the
+  // temporal coverage list) - a starting point only, never overwrites a
+  // value the curator already typed, and stays a normal editable field.
+  useEffect(() => {
+    if (csvFiles.length === 0) return;
+    let cancelled = false;
+    setCoverageInferError('');
+    api
+      .adminInferDatasetCoverage(csvFiles)
+      .then((result) => {
+        if (cancelled) return;
+        const filled: Record<string, boolean> = {};
+        if (result.spatialCoverage && !spatialCoverage) {
+          setSpatialCoverage(result.spatialCoverage);
+          filled.spatialCoverage = true;
+        }
+        if (result.spatialResolution && !spatialResolution) {
+          setSpatialResolution(result.spatialResolution);
+          filled.spatialResolution = true;
+        }
+        if (result.temporalCoverage && !temporalCoverage) {
+          setTemporalCoverage(result.temporalCoverage);
+          filled.temporalCoverage = true;
+        }
+        if (Object.keys(filled).length > 0) {
+          setCoverageAutoFilled((prev) => ({ ...prev, ...filled }));
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setCoverageInferError(
+            errorMessage(err, 'Could not auto-detect coverage fields — fill them in manually below.')
+          );
+        }
       });
     return () => {
       cancelled = true;
@@ -522,7 +684,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
 
       <div class="grid gap-3 md:grid-cols-2">
         <label class="block text-xs font-medium text-slate-600 md:col-span-2">
-          Raw CSV(s) — select more than one for a multi-table dataset
+          <span class="inline-flex items-center">
+            Raw CSV(s) — select more than one for a multi-table dataset
+            <FieldHint text="The actual data file(s) for this dataset. Upload one CSV per table — if you select more than one, each becomes its own table inside a single multi-table dataset." />
+          </span>
           <input
             type="file"
             accept=".csv"
@@ -538,7 +703,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
         </label>
 
         <label class="block text-xs font-medium text-slate-600">
-          Category
+          <span class="inline-flex items-center">
+            Category
+            <FieldHint text="The top-level subject area this dataset belongs to, e.g. 'Census and Surveys'. Pick the closest match — this decides where the dataset is filed in the catalog." />
+          </span>
           <select
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={categoryId}
@@ -556,7 +724,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           </select>
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Collection
+          <span class="inline-flex items-center">
+            Collection
+            <FieldHint text="The specific group of related datasets this one belongs to within the category above, e.g. 'Livestock Census'." />
+          </span>
           <select
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={collectionId}
@@ -572,7 +743,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           </select>
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Data owner
+          <span class="inline-flex items-center">
+            Data owner
+            <FieldHint text="The organisation or person responsible for this data — who to credit, and who to contact with questions about it." />
+          </span>
           <select
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={dataOwnerName}
@@ -587,7 +761,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           </select>
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Existing dataset ID (optional — leave blank to auto-assign the next available ID)
+          <span class="inline-flex items-center">
+            Existing dataset ID (optional — leave blank to auto-assign the next available ID)
+            <FieldHint text="Only fill this in if you're replacing/updating a dataset that's already published. For a brand-new dataset, leave this blank — an ID is assigned automatically." />
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={datasetId}
@@ -596,7 +773,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
         </label>
         {csvFiles.length > 1 ? (
           <label class="block text-xs font-medium text-slate-600 md:col-span-2">
-            Dataset title — required with multiple CSVs (a single CSV is always named after its own filename)
+            <span class="inline-flex items-center">
+              Dataset title — required with multiple CSVs (a single CSV is always named after its own filename)
+              <FieldHint text="A short, URL-friendly name for the dataset as a whole (not any single table), e.g. 'bahs-milk-production-statistics-1950-2024'. Only needed when you've uploaded more than one CSV." />
+            </span>
             <input
               class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
               value={datasetTitle}
@@ -607,7 +787,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
         ) : null}
 
         <label class="block text-xs font-medium text-slate-600 md:col-span-2">
-          Dataset description
+          <span class="inline-flex items-center">
+            Dataset description
+            <FieldHint text="A plain-language summary of what this dataset contains: what each row represents, and what it's broken down by (e.g. state x year x species)." />
+          </span>
           <textarea
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             rows={2}
@@ -619,6 +802,7 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
         <div class="md:col-span-2">
           <RepeatableTextList
             label="Source document(s) — optional, one citation per entry"
+            hint="Where this data originally came from — the report, survey, or publication it was extracted from, e.g. '16th Livestock Census 1997 – Department of Animal Husbandry'."
             values={source}
             onChange={setSource}
             placeholder="e.g. 16th Livestock Census 1997 – Department of Animal Husbandry, Dairying & Fisheries, Government of India"
@@ -627,13 +811,17 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
         <div class="md:col-span-2">
           <RepeatableTextList
             label="References / URLs — optional, one per entry"
+            hint="Links to the original source document(s) online, if publicly available, so a future user can go look them up."
             values={references}
             onChange={setReferences}
             placeholder="e.g. https://dahd.gov.in/sites/default/files/2019-12/16thLivestockCensusBook.pdf"
           />
         </div>
         <label class="block text-xs font-medium text-slate-600">
-          Tags — concept (comma-separated)
+          <span class="inline-flex items-center">
+            Tags — concept (comma-separated)
+            <FieldHint text="Keywords describing the subject matter, used to help people find this dataset when searching or browsing the catalog, e.g. 'livestock, cattle, buffalo'." />
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={tagsConcept}
@@ -642,7 +830,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           />
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Tags — epiType (comma-separated)
+          <span class="inline-flex items-center">
+            Tags — epiType (comma-separated)
+            <FieldHint text="The kind of measurement this dataset records, e.g. 'population', 'incidence', 'mortality'." />
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={tagsEpiType}
@@ -651,60 +842,88 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
           />
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Spatial coverage
+          <span class="inline-flex items-center">
+            Spatial coverage
+            <FieldHint text="The geographic area this dataset covers, e.g. 'India', or a specific state/region. Auto-detected as 'India' when a state/UT-level region column is found - check it's right." />
+            {coverageAutoFilled.spatialCoverage ? <AutoDetectedBadge /> : null}
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={spatialCoverage}
             placeholder="e.g. india"
-            onInput={(e) => setSpatialCoverage((e.target as HTMLInputElement).value)}
+            onInput={(e) => {
+              setSpatialCoverage((e.target as HTMLInputElement).value);
+              clearAutoFilled('spatialCoverage');
+            }}
           />
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Spatial resolution
+          <span class="inline-flex items-center">
+            Spatial resolution
+            <FieldHint text="The smallest geographic unit each row represents, e.g. 'state', 'district', or 'village'. Auto-detected from the finest-grained region column found - check it's right." />
+            {coverageAutoFilled.spatialResolution ? <AutoDetectedBadge /> : null}
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={spatialResolution}
             placeholder="e.g. state"
-            onInput={(e) => setSpatialResolution((e.target as HTMLInputElement).value)}
+            onInput={(e) => {
+              setSpatialResolution((e.target as HTMLInputElement).value);
+              clearAutoFilled('spatialResolution');
+            }}
           />
         </label>
         <label class="block text-xs font-medium text-slate-600">
-          Temporal coverage
+          <span class="inline-flex items-center">
+            Temporal coverage
+            <FieldHint text="The years or time period this dataset covers, e.g. '1997, 2003, 2007, 2012, 2019' for irregular census years, or '1950-2024' for a continuous range. Auto-detected from a year-typed column's observed values - check it's right." />
+            {coverageAutoFilled.temporalCoverage ? <AutoDetectedBadge /> : null}
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={temporalCoverage}
             placeholder="e.g. 1997, 2003, 2007, 2012, 2019"
-            onInput={(e) => setTemporalCoverage((e.target as HTMLInputElement).value)}
+            onInput={(e) => {
+              setTemporalCoverage((e.target as HTMLInputElement).value);
+              clearAutoFilled('temporalCoverage');
+            }}
           />
         </label>
-        <label class="block text-xs font-medium text-slate-600">
-          Temporal resolution
-          <input
-            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
-            value={temporalResolution}
-            placeholder="e.g. quinquennial"
-            onInput={(e) => setTemporalResolution((e.target as HTMLInputElement).value)}
-          />
-        </label>
-        <label class="block text-xs font-medium text-slate-600">
-          Update frequency
-          <input
-            class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
-            value={updateFrequency}
-            placeholder="e.g. quinquennial"
-            onInput={(e) => setUpdateFrequency((e.target as HTMLInputElement).value)}
-          />
-        </label>
+        {coverageInferError ? (
+          <div class="rounded-lg bg-amber-50 p-2 text-[11px] text-amber-700 ring-1 ring-amber-200 md:col-span-2">
+            {coverageInferError}
+          </div>
+        ) : null}
+        <PresetSelectField
+          label="Temporal resolution"
+          hint="How often the data is recorded/reported, e.g. 'Annual', 'Quinquennial' (every 5 years), 'Monthly'."
+          value={temporalResolution}
+          onChange={setTemporalResolution}
+          options={TEMPORAL_RESOLUTION_OPTIONS}
+          placeholder="e.g. survey round (single cross-section)"
+        />
+        <PresetSelectField
+          label="Update frequency"
+          hint="How often this dataset itself is expected to be refreshed with new data going forward, e.g. 'Annual', 'Quinquennial', 'One-time'."
+          value={updateFrequency}
+          onChange={setUpdateFrequency}
+          options={UPDATE_FREQUENCY_OPTIONS}
+          placeholder="e.g. Survey-round basis (not annual)"
+        />
         <div class="md:col-span-2">
           <RepeatableTextList
             label="Comments — optional analyst notes, one per entry (region-history notes are added automatically, no need to repeat them here)"
+            hint="Any other useful fact about the data a future user should know — units used, known gaps, caveats, or how a value was derived. One distinct fact per entry."
             values={comments}
             onChange={setComments}
             placeholder="e.g. The 'total' locality row equals rural + urban exactly for every observation."
           />
         </div>
         <label class="block text-xs font-medium text-slate-600 md:col-span-2">
-          Join key columns (comma-separated, optional — leave blank to accept the auto-suggested candidates)
+          <span class="inline-flex items-center">
+            Join key columns (comma-separated, optional — leave blank to accept the auto-suggested candidates)
+            <FieldHint text="The column(s) that together uniquely identify each row and would be used to combine/join this data with other datasets, e.g. 'state.ID, year'. Leave blank to accept the automatically-suggested columns." />
+          </span>
           <input
             class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
             value={joinKeyColumns}
@@ -721,7 +940,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
             {tableNames.map((name) => (
               <div key={name} class="space-y-2 rounded-xl border border-slate-100 p-3">
                 <label class="block text-xs font-medium text-slate-600">
-                  <span>Table description — {name}</span>
+                  <span class="inline-flex items-center">
+                    Table description — {name}
+                    <FieldHint text="A plain-language summary of what this specific table/CSV contains — if the dataset has multiple tables, how this one differs from the others." />
+                  </span>
                   <textarea
                     class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
                     rows={2}
@@ -740,7 +962,10 @@ function GenerateDeterministicDraftForm({ onGenerated }: { onGenerated: () => vo
                     </p>
                     {(columnsByTable[name] || []).map((col) => (
                       <label key={col} class="block text-xs font-medium text-slate-600">
-                        {col}
+                        <span class="inline-flex items-center">
+                          {col}
+                          <FieldHint text="Explain in plain language what this column represents and what its values mean — this column's type/format was already worked out automatically, only a human-readable description is needed here." />
+                        </span>
                         <input
                           class="mt-1 w-full rounded-lg border border-slate-300 px-2 py-1.5 text-sm"
                           value={columnDescriptions[name]?.[col] || ''}
@@ -940,6 +1165,11 @@ function DraftDetail({ draftId }: { draftId: string }) {
   const [infoYamlAccessLevel, setInfoYamlAccessLevel] = useState<AccessLevel>('NONE');
   const [infoYamlBusy, setInfoYamlBusy] = useState(false);
   const [infoYamlError, setInfoYamlError] = useState('');
+  const [uploadAccessLevel, setUploadAccessLevel] = useState<AccessLevel>('NONE');
+  const [uploadBucketType, setUploadBucketType] = useState('STANDARDISED');
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+  const [uploadResult, setUploadResult] = useState<{ dataset_id: string; uploaded_tables: string[] } | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -1016,6 +1246,21 @@ function DraftDetail({ draftId }: { draftId: string }) {
       setInfoYamlError(errorMessage(err, 'Failed to generate info.yml'));
     } finally {
       setInfoYamlBusy(false);
+    }
+  };
+
+  const uploadDatasetNow = async () => {
+    setUploadBusy(true);
+    setUploadError('');
+    setUploadResult(null);
+    try {
+      const result = await api.adminImportDatasetFromDraft(draftId, uploadAccessLevel, uploadBucketType);
+      setUploadResult({ dataset_id: result.dataset_id, uploaded_tables: result.uploaded_tables });
+      await load(); // refreshes draft.dataset_exists now that it's live
+    } catch (err) {
+      setUploadError(errorMessage(err, 'Failed to upload dataset'));
+    } finally {
+      setUploadBusy(false);
     }
   };
 
@@ -1266,7 +1511,7 @@ function DraftDetail({ draftId }: { draftId: string }) {
             <h3 class="text-sm font-semibold text-slate-900">Generate info.yml</h3>
             <p class="mt-1 text-xs text-slate-500">
               {draft.status === 'approved'
-                ? "The second file the real dataset import needs, alongside metadata.yaml - derived from this draft's reviewed fields. Access level isn't captured anywhere upstream, so pick it here before downloading."
+                ? "info.yml is the second file, alongside metadata.yaml, that the dataset import step needs to turn this draft into a real, live dataset. It carries the catalog-level fields metadata.yaml doesn't - dataset ID, collection, title, data owner, description, temporal coverage & resolution, spatial resolution, and the raw dataset's ID & source - plus access level (who can view/download this dataset), which isn't captured anywhere upstream, so pick it here before generating. metadata.yaml + info.yml together are exactly what the Import / Create Dataset tab (or the \"Upload dataset now\" button below) needs."
                 : 'Available once this draft is approved, so info.yml reflects the final reviewed manifest rather than a still-changeable draft. Approve it above first.'}
             </p>
           </div>
@@ -1379,6 +1624,63 @@ function DraftDetail({ draftId }: { draftId: string }) {
           {findingRows(draft.validation_result.findings)}
         </div>
       ) : null}
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <div>
+            <h3 class="text-sm font-semibold text-slate-900">Upload dataset now</h3>
+            <p class="mt-1 text-xs text-slate-500">
+              {draft.status !== 'approved'
+                ? 'Available once this draft is approved. Approve it above first.'
+                : draft.dataset_exists === true || uploadResult
+                  ? 'This draft has already been uploaded to the DataIO catalog. To make further changes to the live dataset, use the Import / Create Dataset tab.'
+                  : 'Publishes this approved draft straight to the DataIO catalog - the same process as the Import / Create Dataset tab, without the manual download-and-re-upload step. Use this right after generating a draft’s metadata. For uploads later on, or from outside this draft flow, use the Import / Create Dataset tab instead.'}
+            </p>
+          </div>
+          <div class="flex shrink-0 items-center gap-2">
+            <select
+              class="rounded-lg border border-slate-300 px-2 py-1 text-xs disabled:opacity-50"
+              value={uploadAccessLevel}
+              disabled={uploadBusy || draft.status !== 'approved' || draft.dataset_exists === true || !!uploadResult}
+              onChange={(e) => setUploadAccessLevel((e.target as HTMLSelectElement).value as AccessLevel)}
+            >
+              <option value="NONE">NONE</option>
+              <option value="VIEW">VIEW</option>
+              <option value="DOWNLOAD">DOWNLOAD</option>
+            </select>
+            <select
+              class="rounded-lg border border-slate-300 px-2 py-1 text-xs disabled:opacity-50"
+              value={uploadBucketType}
+              disabled={uploadBusy || draft.status !== 'approved' || draft.dataset_exists === true || !!uploadResult}
+              onChange={(e) => setUploadBucketType((e.target as HTMLSelectElement).value)}
+            >
+              <option value="STANDARDISED">STANDARDISED</option>
+              <option value="PREPROCESSED">PREPROCESSED</option>
+            </select>
+            <button
+              type="button"
+              disabled={uploadBusy || draft.status !== 'approved' || draft.dataset_exists === true || !!uploadResult}
+              onClick={uploadDatasetNow}
+              class="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {uploadBusy
+                ? 'Uploading…'
+                : draft.dataset_exists === true || uploadResult
+                  ? 'Already uploaded'
+                  : 'Upload dataset now'}
+            </button>
+          </div>
+        </div>
+        {uploadResult ? (
+          <div class="rounded-lg bg-emerald-50 p-2 text-xs text-emerald-700 ring-1 ring-emerald-200">
+            Uploaded dataset <span class="font-mono">{uploadResult.dataset_id}</span> ({uploadResult.uploaded_tables.length}{' '}
+            table{uploadResult.uploaded_tables.length === 1 ? '' : 's'}).
+          </div>
+        ) : null}
+        {uploadError ? (
+          <div class="rounded-lg bg-red-50 p-2 text-xs text-red-700 ring-1 ring-red-200">{uploadError}</div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/components/common/Sidebar.tsx
+++ b/web/src/components/common/Sidebar.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 import { currentUser } from '../../lib/auth';
 
 interface NavItem {
@@ -21,9 +22,11 @@ const navItems: NavItem[] = [
     adminOnly: true,
     children: [
       { name: 'Overview', href: '/admin/datasets' },
+      { name: 'Metadata Drafts', href: '/admin/datasets/drafts' },
       { name: 'Create / Import', href: '/admin/datasets/new' },
       { name: 'Catalog', href: '/admin/datasets/catalog' },
       { name: 'Reserved IDs', href: '/admin/datasets/reservations' },
+      { name: 'Next ID', href: '/admin/datasets/next-id' },
       { name: 'Documentation Sync', href: '/admin/datasets/sync' },
     ],
   },
@@ -87,6 +90,35 @@ export default function Sidebar() {
 
   const filteredItems = navItems.filter((item) => !item.adminOnly || isAdmin);
 
+  // Collapsed by default; a section auto-expands if the current page is one
+  // of its children, so landing directly on e.g. /admin/datasets/drafts
+  // doesn't leave the sidebar looking empty.
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    for (const item of navItems) {
+      if (
+        item.children?.some(
+          (child) => currentPath === child.href || currentPath.startsWith(child.href + '/')
+        )
+      ) {
+        initial.add(item.name);
+      }
+    }
+    return initial;
+  });
+
+  const toggleSection = (name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
   return (
     <aside class="hidden lg:flex lg:flex-shrink-0">
       <div class="flex flex-col w-64 fixed inset-y-0 pt-16">
@@ -116,23 +148,52 @@ export default function Sidebar() {
                       {item.name}
                     </a>
                   ) : (
-                    <div
-                      class={`flex items-center px-3 py-2 text-sm font-semibold rounded-lg ${
+                    <button
+                      type="button"
+                      onClick={() => toggleSection(item.name)}
+                      aria-expanded={expanded.has(item.name)}
+                      class={`w-full flex items-center justify-between px-3 py-2 text-sm font-semibold rounded-lg hover:bg-gray-50 ${
                         isActive ? 'text-primary-700' : 'text-gray-700'
                       }`}
                     >
-                      <span class={`mr-3 ${isActive ? 'text-primary-600' : 'text-gray-400'}`}>
-                        {icons[item.icon]}
+                      <span class="flex items-center">
+                        <span class={`mr-3 ${isActive ? 'text-primary-600' : 'text-gray-400'}`}>
+                          {icons[item.icon]}
+                        </span>
+                        {item.name}
                       </span>
-                      {item.name}
-                    </div>
+                      <svg
+                        class={`w-4 h-4 text-gray-400 transition-transform ${
+                          expanded.has(item.name) ? 'rotate-90' : ''
+                        }`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </button>
                   )}
 
-                  {item.children ? (
+                  {item.children && expanded.has(item.name) ? (
                     <div class="ml-11 mt-1 space-y-1">
                       {item.children.map((child) => {
-                        const childActive =
-                          currentPath === child.href || currentPath.startsWith(child.href + '/');
+                        // A link whose href is itself a prefix of a sibling's
+                        // href (e.g. "Overview" -> /admin/datasets, sibling
+                        // "Catalog" -> /admin/datasets/catalog) must match
+                        // exactly - otherwise it lights up on every sibling
+                        // page too, since its own path is a prefix of theirs.
+                        const isAncestorOfSibling = item.children!.some(
+                          (sibling) => sibling.href !== child.href && sibling.href.startsWith(child.href + '/')
+                        );
+                        const childActive = isAncestorOfSibling
+                          ? currentPath === child.href
+                          : currentPath === child.href || currentPath.startsWith(child.href + '/');
                         return (
                           <a
                             key={child.href}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1182,6 +1182,18 @@ class ApiClient {
     );
   }
 
+  async adminInferDatasetCoverage(csvFiles: File[]) {
+    const formData = new FormData();
+    for (const file of csvFiles) {
+      formData.append('csv_files', file);
+    }
+    return this.request<{
+      spatialCoverage: string | null;
+      spatialResolution: string | null;
+      temporalCoverage: string | null;
+    }>('/admin/manifest-drafts/infer-coverage', { method: 'POST', body: formData });
+  }
+
   async adminListManifestDrafts(params?: { status?: string; datasetId?: string; limit?: number; offset?: number }) {
     const query = new URLSearchParams();
     if (params?.status) query.set('status', params.status);
@@ -1252,6 +1264,18 @@ class ApiClient {
       `/admin/manifest-drafts/${encodeURIComponent(draftId)}/info-yaml`,
       { method: 'POST', body: JSON.stringify({ access_level: accessLevel }) }
     );
+  }
+
+  async adminImportDatasetFromDraft(draftId: string, accessLevel: AccessLevel, bucketType: string) {
+    return this.request<{
+      dataset_id: string;
+      bucket_type: string;
+      uploaded_tables: string[];
+      manifest_uploaded: boolean;
+    }>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/import`, {
+      method: 'POST',
+      body: JSON.stringify({ access_level: accessLevel, bucket_type: bucketType }),
+    });
   }
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   CollectionsResponse,
   DatasetDownloadUrls,
   ValidationResult,
+  CuratorMetadataInput,
   ManifestDraftDetail,
   ManifestDraftSummary,
 } from './types';
@@ -1146,6 +1147,40 @@ class ApiClient {
     });
   }
 
+  async adminGenerateDeterministicManifestDraft(params: {
+    csvFiles: File[];
+    categoryId: string;
+    collectionId: string;
+    dataOwnerName: string;
+    curatorInput: CuratorMetadataInput;
+    datasetId?: string;
+  }) {
+    const formData = new FormData();
+    for (const file of params.csvFiles) {
+      formData.append('csv_files', file);
+    }
+    formData.append('category_id', params.categoryId);
+    formData.append('collection_id', params.collectionId);
+    formData.append('data_owner_name', params.dataOwnerName);
+    formData.append('curator_input', JSON.stringify(params.curatorInput));
+    if (params.datasetId) formData.append('dataset_id', params.datasetId);
+
+    return this.request<ManifestDraftDetail>('/admin/manifest-drafts/generate-deterministic', {
+      method: 'POST',
+      body: formData,
+    });
+  }
+
+  async adminClassifyColumns(params: { tableName: string; columnNames: string[] }) {
+    return this.request<{ fixed: string[]; needsDescription: string[] }>(
+      '/admin/manifest-drafts/classify-columns',
+      {
+        method: 'POST',
+        body: JSON.stringify({ table_name: params.tableName, column_names: params.columnNames }),
+      }
+    );
+  }
+
   async adminListManifestDrafts(params?: { status?: string; datasetId?: string; limit?: number; offset?: number }) {
     const query = new URLSearchParams();
     if (params?.status) query.set('status', params.status);
@@ -1188,6 +1223,13 @@ class ApiClient {
     return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/flag-field`, {
       method: 'POST',
       body: JSON.stringify({ field_path: fieldPath, note }),
+    });
+  }
+
+  async adminUpdateManifestDraftContent(draftId: string, draftYaml: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}`, {
+      method: 'PUT',
+      body: JSON.stringify({ draft_yaml: draftYaml }),
     });
   }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,8 @@ import type {
   CollectionsResponse,
   DatasetDownloadUrls,
   ValidationResult,
+  ManifestDraftDetail,
+  ManifestDraftSummary,
 } from './types';
 
 const API_URL = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1';
@@ -1077,9 +1079,12 @@ class ApiClient {
     });
   }
 
-  async adminCheckDocumentationSync(datasetId?: string) {
-    const query = datasetId ? `?dataset_id=${encodeURIComponent(datasetId)}` : '';
-    return this.request<DocumentationSyncCheckResponse>(`/admin/documentation-sync${query}`);
+  async adminCheckDocumentationSync(datasetId?: string, checkAll?: boolean) {
+    const query = new URLSearchParams();
+    if (datasetId) query.set('dataset_id', datasetId);
+    if (checkAll) query.set('check_all', 'true');
+    const qs = query.toString();
+    return this.request<DocumentationSyncCheckResponse>(`/admin/documentation-sync${qs ? `?${qs}` : ''}`);
   }
 
   async adminRunDocumentationSync(payload?: {
@@ -1114,6 +1119,88 @@ class ApiClient {
         method: 'POST',
         body: JSON.stringify(payload),
       }
+    );
+  }
+
+  async adminGenerateManifestDraft(params: {
+    csvFiles: File[];
+    categoryId: string;
+    collectionId: string;
+    dataOwnerName: string;
+    datasetId?: string;
+    digitizationLogFile?: File | null;
+  }) {
+    const formData = new FormData();
+    for (const file of params.csvFiles) {
+      formData.append('csv_files', file);
+    }
+    formData.append('category_id', params.categoryId);
+    formData.append('collection_id', params.collectionId);
+    formData.append('data_owner_name', params.dataOwnerName);
+    if (params.datasetId) formData.append('dataset_id', params.datasetId);
+    if (params.digitizationLogFile) formData.append('digitization_log_file', params.digitizationLogFile);
+
+    return this.request<ManifestDraftDetail>('/admin/manifest-drafts/generate', {
+      method: 'POST',
+      body: formData,
+    });
+  }
+
+  async adminListManifestDrafts(params?: { status?: string; datasetId?: string; limit?: number; offset?: number }) {
+    const query = new URLSearchParams();
+    if (params?.status) query.set('status', params.status);
+    if (params?.datasetId) query.set('dataset_id', params.datasetId);
+    if (params?.limit) query.set('limit', String(params.limit));
+    if (params?.offset) query.set('offset', String(params.offset));
+    const qs = query.toString();
+    return this.request<{ drafts: ManifestDraftSummary[]; total: number }>(
+      `/admin/manifest-drafts${qs ? `?${qs}` : ''}`
+    );
+  }
+
+  async adminGetManifestDraft(draftId: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}`);
+  }
+
+  async adminValidateManifestDraft(draftId: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/validate`, {
+      method: 'POST',
+    });
+  }
+
+  async adminApproveManifestDraft(draftId: string) {
+    // Lightweight accept only - this tool generates/validates/downloads,
+    // it doesn't upload anything to S3/Postgres. The draft's dataset_id
+    // was already reserved at generation time and just stays reserved.
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/approve`, {
+      method: 'POST',
+    });
+  }
+
+  async adminRejectManifestDraft(draftId: string, reason?: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/reject`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    });
+  }
+
+  async adminFlagManifestDraftField(draftId: string, fieldPath: string, note: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/flag-field`, {
+      method: 'POST',
+      body: JSON.stringify({ field_path: fieldPath, note }),
+    });
+  }
+
+  async adminRegenerateManifestDraft(draftId: string) {
+    return this.request<ManifestDraftDetail>(`/admin/manifest-drafts/${encodeURIComponent(draftId)}/regenerate`, {
+      method: 'POST',
+    });
+  }
+
+  async adminDeleteManifestDraft(draftId: string) {
+    return this.request<{ message: string; draft_id: string }>(
+      `/admin/manifest-drafts/${encodeURIComponent(draftId)}`,
+      { method: 'DELETE' }
     );
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  AccessLevel,
   AdminDatasetDetail,
   AdminDatasetPackagePreview,
   AdminDatasetSummary,
@@ -1243,6 +1244,13 @@ class ApiClient {
     return this.request<{ message: string; draft_id: string }>(
       `/admin/manifest-drafts/${encodeURIComponent(draftId)}`,
       { method: 'DELETE' }
+    );
+  }
+
+  async adminGenerateManifestDraftInfoYaml(draftId: string, accessLevel: AccessLevel) {
+    return this.request<{ info_yaml: string }>(
+      `/admin/manifest-drafts/${encodeURIComponent(draftId)}/info-yaml`,
+      { method: 'POST', body: JSON.stringify({ access_level: accessLevel }) }
     );
   }
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -345,3 +345,45 @@ export interface ValidationResult {
   findings: ValidationFinding[];
   inferred: Record<string, unknown>;
 }
+
+export interface ManifestDraftFlaggedField {
+  field: string;
+  reason: string;
+}
+
+export interface ManifestDraftReviewerNote {
+  field?: string;
+  note: string;
+  by: string;
+}
+
+export type ManifestDraftStatus = 'pending' | 'approved' | 'rejected' | 'flagged';
+
+export interface ManifestDraftSummary {
+  draft_id: string;
+  dataset_id: string | null;
+  collection_id: string;
+  category_id: string;
+  status: ManifestDraftStatus;
+  llm_model_id: string;
+  created_by: string;
+  created_at: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  superseded_by_draft_id: string | null;
+}
+
+export interface ManifestDraftDetail extends ManifestDraftSummary {
+  // Whether dataset_id (a reserved ID, always set) already corresponds to
+  // a real Dataset row - a draft with dataset_id set could still be for a
+  // brand-new dataset, since the ID gets reserved before the dataset
+  // actually exists.
+  dataset_exists: boolean | null;
+  source_csv_path: string;
+  digitization_log_path: string | null;
+  draft_yaml: string;
+  draft_json: Record<string, unknown>;
+  flagged_fields: ManifestDraftFlaggedField[];
+  reviewer_notes: ManifestDraftReviewerNote[];
+  validation_result: ValidationResult | null;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -365,12 +365,45 @@ export interface ManifestDraftSummary {
   collection_id: string;
   category_id: string;
   status: ManifestDraftStatus;
-  llm_model_id: string;
+  // null for a deterministic (rule-based, no-LLM) draft - see
+  // adminGenerateDeterministicManifestDraft.
+  llm_model_id: string | null;
   created_by: string;
   created_at: string | null;
   reviewed_by: string | null;
   reviewed_at: string | null;
   superseded_by_draft_id: string | null;
+}
+
+// The manifest fields no deterministic rule can derive from the CSV alone -
+// supplied directly by the curator through the intake form. Mirrors
+// dataio.api.services.deterministic_draft_service.CuratorMetadataInput.
+export interface CuratorMetadataInput {
+  datasetDescription: string;
+  source: string[];
+  references: string[];
+  tags: { concept: string[]; epiType: string[] };
+  spatialCoverage: string;
+  spatialResolution: string;
+  temporalCoverage: string;
+  temporalResolution: string;
+  updateFrequency: string;
+  comments: string[];
+  // The curator's confirmed/edited subset of the auto-suggested join-key
+  // candidates - leave empty to accept the backend's own suggestion.
+  joinKeyColumns: string[];
+  // Required, one entry per table (keyed by table name - the CSV filename
+  // without its extension). No rule can derive real table-level narrative
+  // from a CSV alone.
+  tableDescriptions: Record<string, string>;
+  // Required, one entry per column not classified as "fixed" by
+  // /admin/manifest-drafts/classify-columns (keyed table name -> column
+  // name). Region-identifier and source/provenance columns are excluded -
+  // those are auto-filled server-side.
+  columnDescriptions: Record<string, Record<string, string>>;
+  // Only meaningful (and required) with 2+ CSVs - a single-CSV dataset is
+  // always named after that CSV's own filename regardless of this value.
+  datasetTitle: string;
 }
 
 export interface ManifestDraftDetail extends ManifestDraftSummary {

--- a/web/src/pages/admin/datasets/drafts.astro
+++ b/web/src/pages/admin/datasets/drafts.astro
@@ -1,0 +1,25 @@
+---
+import AdminDatasetsSubnav from '../../../components/admin/AdminDatasetsSubnav.astro';
+import DraftReviewManager from '../../../components/admin/DraftReviewManager';
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+---
+
+<DashboardLayout title="Metadata Drafts" fullWidth={true}>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Metadata Drafts</h1>
+      <p class="mt-1 text-gray-600">
+        LLM-drafted metadata.yaml pending curator review, before anything is uploaded.
+      </p>
+    </div>
+
+    <AdminDatasetsSubnav />
+    <DraftReviewManager client:load />
+  </div>
+</DashboardLayout>
+
+<script>
+  import { requireAuthenticatedPage } from '../../../lib/auth';
+
+  requireAuthenticatedPage({ adminOnly: true });
+</script>

--- a/web/src/pages/admin/datasets/drafts/view.astro
+++ b/web/src/pages/admin/datasets/drafts/view.astro
@@ -1,0 +1,23 @@
+---
+import AdminDatasetsSubnav from '../../../../components/admin/AdminDatasetsSubnav.astro';
+import { DraftReviewDetail } from '../../../../components/admin/DraftReviewManager';
+import DashboardLayout from '../../../../layouts/DashboardLayout.astro';
+---
+
+<DashboardLayout title="Review Manifest Draft" fullWidth={true}>
+  <div class="space-y-6">
+    <div>
+      <a href="/admin/datasets/drafts" class="text-sm text-slate-500 hover:text-slate-700">&larr; Back to drafts</a>
+      <h1 class="mt-2 text-2xl font-bold text-gray-900">Review Manifest Draft</h1>
+    </div>
+
+    <AdminDatasetsSubnav />
+    <DraftReviewDetail client:load />
+  </div>
+</DashboardLayout>
+
+<script>
+  import { requireAuthenticatedPage } from '../../../../lib/auth';
+
+  requireAuthenticatedPage({ adminOnly: true });
+</script>


### PR DESCRIPTION
## Summary
- Cut down what the LLM drafter sends per table (no more full raw CSV text) by moving type/nullable/joinKeys/canonicalEnumDefinitions and region-history comments to deterministic code shared with the rule-based drafter - fixes a production 502 from an oversized prompt, and gives clearer errors when OpenRouter itself fails.
- Add "Upload dataset now" on the Draft Detail screen - publishes an approved draft straight to the catalog via the existing import pipeline, without the manual metadata.yaml/info.yml download-and-re-upload round trip; disables itself once the dataset is live.
- Deterministic draft form: hover hints on every field, dropdowns (with a free-text escape hatch) for temporal resolution/update frequency, and auto-detected spatialCoverage/spatialResolution/temporalCoverage suggestions from the uploaded CSVs (still fully editable).
- Fix a pre-existing `.gitignore` gap that silently excluded two reference-data YAML files (`region_history.yaml`, `canonical_enum_registry.yaml`) the deterministic drafter depends on at runtime - now tracked.

## Test plan
- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest src/dataio/api/tests/ -q` - full pass except 6 pre-existing, unrelated `test_permissions.py` failures (missing local fixture file, present on staging today independent of this branch)
- [x] Frontend: `npx astro check` - 0 errors; `npm run build` - succeeds
- [x] Dry-run merge of this branch into `origin/staging` in an isolated worktree - no conflicts, same test/build results as above
- [ ] Manual: approve a real draft in staging and click "Upload dataset now" end-to-end (not exercised in this environment - no live DB/S3 access)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin Metadata Drafts workflow for generating, reviewing, editing, validating, approving, rejecting, flagging, regenerating, and importing dataset metadata.
  * Added deterministic CSV profiling, column classification, coverage inference, canonical references, and automatic ID reservation.
  * Added dashboard statistics, navigation, draft detail pages, and direct dataset import.
  * Added support for generating `info.yml` files from approved drafts.
* **Documentation**
  * Updated setup guidance, architecture documentation, configuration examples, and curated reference data.
* **Bug Fixes**
  * Improved documentation-sync reporting and partial-failure handling.
  * Strengthened upload filename safety and raw dataset ID suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->