### PR TITLE
Strip UTF-8 BOM from uploaded CSVs at intake

### DIFF
--- a/src/dataio/api/services/draft_upload_storage.py
+++ b/src/dataio/api/services/draft_upload_storage.py
@@ -18,6 +18,17 @@ from fastapi import UploadFile
 
 DRAFT_UPLOAD_DIR = os.getenv("DRAFT_UPLOAD_DIR", "data/manifest_draft_uploads")
 
+# A CSV saved by Excel as "CSV UTF-8" carries this 3-byte marker at the
+# very start of the file. It's invisible to a human and to pandas (which
+# strips it automatically), but Python's stdlib csv module does not - it
+# silently glues ﻿ onto the first column's name, so e.g. "state.
+# lgd_code" as declared in a manifest no longer matches the actual first
+# column header the file contains, byte for byte. Stripping it here, once,
+# at intake means no CSV saved to disk (or later validated, uploaded to
+# S3, etc.) ever carries one - simpler than making every downstream reader
+# BOM-aware individually.
+_UTF8_BOM = b"\xef\xbb\xbf"
+
 
 def save_upload(upload_file: UploadFile) -> str:
     """Writes an uploaded file to DRAFT_UPLOAD_DIR under a UUID-named
@@ -38,8 +49,13 @@ def save_upload(upload_file: UploadFile) -> str:
 
     # Streamed in chunks (not upload_file.file.read() then write()) - a
     # large CSV would otherwise be buffered whole in memory before any of
-    # it reaches disk.
+    # it reaches disk. Peek at the first 3 bytes to strip a UTF-8 BOM if
+    # present (see _UTF8_BOM above); leave the stream positioned right
+    # after it so copyfileobj picks up from there, or rewind to the very
+    # start if there was no BOM to strip.
     upload_file.file.seek(0)
+    if upload_file.file.read(len(_UTF8_BOM)) != _UTF8_BOM:
+        upload_file.file.seek(0)
     with open(dest_path, "wb") as f:
         shutil.copyfileobj(upload_file.file, f)
 

--- a/src/dataio/api/tests/test_draft_upload_storage.py
+++ b/src/dataio/api/tests/test_draft_upload_storage.py
@@ -19,6 +19,34 @@ def test_save_upload_writes_file_and_returns_path(tmp_path, monkeypatch):
         assert f.read() == b"a,b\n1,2\n"
 
 
+def test_save_upload_strips_leading_utf8_bom(tmp_path, monkeypatch):
+    """A CSV saved by Excel as "CSV UTF-8" carries a 3-byte BOM marker
+    before the first column header - stripping it at intake means it
+    never reaches the validator (or anything else) mismatched against a
+    manifest's clean column names.
+    """
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    bom_prefixed = b"\xef\xbb\xbfstate.lgd_code,name\n29,Karnataka\n"
+    upload = UploadFile(filename="data.csv", file=io.BytesIO(bom_prefixed))
+    saved_path = draft_upload_storage.save_upload(upload)
+
+    with open(saved_path, "rb") as f:
+        content = f.read()
+    assert not content.startswith(draft_upload_storage._UTF8_BOM)
+    assert content == b"state.lgd_code,name\n29,Karnataka\n"
+
+
+def test_save_upload_leaves_non_bom_content_untouched(tmp_path, monkeypatch):
+    monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
+
+    upload = UploadFile(filename="data.csv", file=io.BytesIO(b"state.lgd_code,name\n29,Karnataka\n"))
+    saved_path = draft_upload_storage.save_upload(upload)
+
+    with open(saved_path, "rb") as f:
+        assert f.read() == b"state.lgd_code,name\n29,Karnataka\n"
+
+
 def test_save_upload_is_collision_proof(tmp_path, monkeypatch):
     monkeypatch.setattr(draft_upload_storage, "DRAFT_UPLOAD_DIR", str(tmp_path))
 


### PR DESCRIPTION
## Summary
- `draft_upload_storage.save_upload()` now strips a leading UTF-8 BOM (the 3-byte marker Excel adds when saving "CSV UTF-8") from any uploaded file before it's written to disk.
- Without this, a BOM'd CSV's first column name (e.g. `state.lgd_code`) would silently mismatch against the same column name as declared in the generated manifest during validation - `pandas` (used to profile the CSV and build the manifest) strips the BOM automatically, but the validator's stdlib `csv`-based file read does not, so the two disagreed on the first column's real name and validation failed with "Required column missing" / "Column not declared" / "Value is required but missing" on every row.
- Fixed at the upload/intake layer (not the validator) so every CSV entering the system - draft generation or otherwise - is clean by the time anything downstream reads it, rather than making every reader individually BOM-aware.

Follow-up to #106 (already merged) - this one commit landed on `data-io-v2` right after that PR was merged, so it needs its own PR.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest src/dataio/api/tests/ -q` - full pass except 6 pre-existing, unrelated `test_permissions.py` failures (missing local fixture file)
- [x] New tests: BOM-prefixed upload has the BOM stripped; non-BOM upload is untouched byte-for-byte
- [ ] Manual: re-upload the dataset that originally hit the "state.lgd_code" validation failure and confirm it now generates cleanly (not exercised here - no live DB/S3 access in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uploading CSV files with a leading UTF-8 BOM now removes the BOM before saving.
  * Files without a BOM remain unchanged, preserving their original content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->